### PR TITLE
[Ready for review] Schema tweaks and sitewide breadcrumbs

### DIFF
--- a/assets/siteConstants.js
+++ b/assets/siteConstants.js
@@ -1,6 +1,6 @@
 const SITE_URL=process.env.SITE_URL || 'https://audioxide.com';
 const SITE_NAME='Audioxide';
-const SITE_DESCRIPTION='Independent music webzine. Publishes reviews, articles, interviews, and other oddities.';
+const SITE_DESCRIPTION='Three friends reviewing an album a week. Also publish articles, interviews, and other oddities when then mood takes them.';
 const SITE_FOUNDING_YEAR=2015;
 
 // Content channels

--- a/assets/utilities.ts
+++ b/assets/utilities.ts
@@ -1,3 +1,4 @@
+import { Route } from 'vue-router';
 import he from 'he';
 import {
     SITE_DESCRIPTION,
@@ -107,6 +108,16 @@ const audioxideStructuredData = () => ({
     sameAs: [ FACEBOOK_URL, TWITTER_URL, INSTAGRAM_URL ],
 });
 
+const generateBreadcrumbs = (route: Route, titles: Array<string | null> = []) => ({
+    '@type': 'BreadcrumbList',
+    'itemListElement': route.path.substr(1).split('/').map((part, ind, arr) => ({
+        '@type': 'ListItem',
+        position: ind + 1,
+        item: 'https://audioxide.com/' + arr.slice(0, ind + 1).join('/'),
+        name: titles[ind] || toTitleCase(part, '-'),
+    })),
+});
+
 export {
     rand,
     padNum,
@@ -117,4 +128,5 @@ export {
     throttle,
     resolveAuthorLink,
     audioxideStructuredData,
+    generateBreadcrumbs,
 }

--- a/components/RelatedPosts.vue
+++ b/components/RelatedPosts.vue
@@ -36,7 +36,7 @@ h3 {
     @include section-heading;
 }
 
-.post-item {
+.listing .post-item {
     display: flex;
     ::v-deep {
         @include postLinkFlex;
@@ -48,21 +48,20 @@ h3 {
         display: flex;
         flex-wrap: wrap;
         justify-content: space-between;
-    }
-
-    .post-item {
-        width: calc(50% - 1em);
-        display: block;
-        ::v-deep {
-            .img-wrap {
-                margin-right: 0;
+        .post-item {
+            width: calc(50% - 1em);
+            display: block;
+            ::v-deep {
+                .img-wrap {
+                    margin-right: 0;
+                }
             }
         }
     }
 }
 
 @include medium {
-    .post-item {
+    .listing .post-item {
         width: calc(25% - 1em);
         ::v-deep {
             h4 {

--- a/generateRoutes.js
+++ b/generateRoutes.js
@@ -9,10 +9,11 @@ const getData = (route) => fetch(`${process.env.EXT_API_URL}/${route}.json`).the
 const cacheFilePath = path.resolve(__dirname, './routes.json');
 
 module.exports = async () => {
-    const routes = ['/'];
-    const types = await getData('types');
-    types.pages.forEach(route => routes.push(`/${route}`));
     if (fs.existsSync(cacheFilePath)) return JSON.parse(await fs.promises.readFile(cacheFilePath));
+    const routes = ['/'];
+    const [types, tags] = await Promise.all([getData('types'), getData('tags')]);
+    types.pages.forEach(route => routes.push(`/${route}`));
+    tags.forEach(tag => routes.push(`/tags/${tag.replace(/ /g, '-')}`));
     await Promise.all(
         types.postTypes
             .map(type => routes.push(`/${type}`) && getData(type)

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,12 +2,6 @@
   publish = "dist/"
   command = "export SITE_URL=$URL && export EXT_API_URL=$GAGA_API_URL && sed -i \"s|SITE_URL|${URL}|g\" netlify.toml && sed -i \"s|EXT_API_URL|${EXT_API_URL}|g\" netlify.toml && export API_URL=$SITE_URL/api && export SEARCH_URL=$EXT_API_URL/search && yarn setup && yarn generate"
 
-[context.beta]
-  command = "export SITE_URL=$DEPLOY_PRIME_URL && export EXT_API_URL=$BETA_API_URL && sed -i \"s|SITE_URL|${DEPLOY_PRIME_URL}|g\" netlify.toml && sed -i \"s|EXT_API_URL|${EXT_API_URL}|g\" netlify.toml && export API_URL=$SITE_URL/api && export SEARCH_URL=$EXT_API_URL/search && yarn setup && yarn generate"
-
-[context.alpha]
-  command = "export SITE_URL=$DEPLOY_PRIME_URL && export EXT_API_URL=$ALPHA_API_URL && sed -i \"s|SITE_URL|${DEPLOY_PRIME_URL}|g\" netlify.toml && sed -i \"s|EXT_API_URL|${EXT_API_URL}|g\" netlify.toml && export API_URL=$SITE_URL/api && export SEARCH_URL=$EXT_API_URL/search && yarn setup && yarn generate"
-
 [context.deploy-preview]
   command = "export SITE_URL=$DEPLOY_PRIME_URL && export EXT_API_URL=$ALPHA_API_URL && sed -i \"s|SITE_URL|${DEPLOY_PRIME_URL}|g\" netlify.toml && sed -i \"s|EXT_API_URL|${EXT_API_URL}|g\" netlify.toml && export API_URL=$SITE_URL/api && export SEARCH_URL=$EXT_API_URL/search && yarn setup && yarn generate"
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -11,7 +11,7 @@ const {
   RSS_URL,
 } = require('./assets/siteConstants');
 
-const routes = fs.existsSync('./routes.json') ? JSON.parse(fs.readFileSync('./routes.json')) : [];
+const routes = fs.existsSync('./routes.json') ? JSON.parse(fs.readFileSync('./routes.json')) : ['/'];
 
 const routeDepth = (urlPath) => urlPath.replace(/[^/]+/g, '').length;
 

--- a/pages/_type/_slug.vue
+++ b/pages/_type/_slug.vue
@@ -35,7 +35,7 @@ import NewsletterSignup from '../../components/NewsletterSignup.vue';
 import RelatedPosts from '@/components/RelatedPosts.vue';
 import { MetaInfo, ScriptPropertyJson } from 'vue-meta';
 import { formatISO } from 'date-fns';
-import { resolveAuthorLink, isObject, metaTitle, toTitleCase, audioxideStructuredData } from '../../assets/utilities';
+import { resolveAuthorLink, isObject, metaTitle, toTitleCase, audioxideStructuredData, generateBreadcrumbs } from '../../assets/utilities';
 
 type PostColours = [string, string, string];
 type ColourStyles = { [key: string]: string };
@@ -107,7 +107,16 @@ export default Vue.extend({
                     image: (metadata.featuredimage || {})['medium-standard'] || '',
                     datePublished,
                     dateModified,
+                    "speakable": {
+                        "@type": "SpeakableSpecification",
+                        "cssSelector": [
+                            ".site-content .article-header__heading",
+                            ".site-content .article-header__summary",
+                            ".site-content .article-content",
+                        ],
+                    },
                     publisher: audioxideStructuredData(),
+                    breadcrumb: generateBreadcrumbs(this.$route, [null, metadata.title]),
                 },
             }];
 

--- a/pages/_type/_slug.vue
+++ b/pages/_type/_slug.vue
@@ -104,6 +104,7 @@ export default Vue.extend({
                     '@type': 'Article',
                     headline: metadata.title,
                     description: metadata.summary || metadata.blurb || '',
+                    image: (metadata.featuredimage || {})['medium-standard'] || '',
                     datePublished,
                     dateModified,
                     publisher: audioxideStructuredData(),

--- a/pages/_type/index.vue
+++ b/pages/_type/index.vue
@@ -19,13 +19,23 @@ import { MetaInfo } from 'vue-meta';
 import PostSingle from '@/components/PostSingle.vue';
 import PostListing from '@/components/PostListing.vue';
 import ArticleLink from '@/components/ArticleLink.vue';
-import { metaTitle, toTitleCase } from '~/assets/utilities';
+import { audioxideStructuredData, generateBreadcrumbs, metaTitle, toTitleCase } from '~/assets/utilities';
 
 type ContentTypes = { pages: string[]; postTypes: string[] }
 const isPost = (type: string, types: ContentTypes) =>
   types.postTypes.includes(type);
 const isPage = (type: string, types: ContentTypes) =>
   types.pages.includes(type);
+const ldJsonType = (slug: string) => {
+  switch(slug) {
+    case 'about':
+      return 'AboutPage';
+    case 'contact':
+      return 'ContactPage';
+    default:
+      return 'WebPage';
+  }
+};
 
 export default Vue.extend({
   name: 'ArticleListing',
@@ -38,10 +48,27 @@ export default Vue.extend({
     let title = '';
     const metaData: MetaInfo = {};
     metaData.link = [];
+    metaData.script = [];
     switch (this.type) {
       case 'page':
         const page = this.pageData as Post;
         metaData.title = he.decode(page.metadata.title);
+        metaData.script.push(
+          {
+              type: 'application/ld+json',
+              json: {
+                  '@context': 'http://schema.org',
+                  '@type': ldJsonType(this.slug),
+                  name: he.decode(page.metadata.title),
+                  "speakable": {
+                      "@type": "SpeakableSpecification",
+                      "cssSelector": [".site-content .post-header__heading", ".site-content .post-content"]
+                  },
+                  publisher: audioxideStructuredData(),
+                  breadcrumb: generateBreadcrumbs(this.$route),
+              }
+          },
+        );
         break;
       case 'post':
         const title = toTitleCase(this.slug, '-');
@@ -52,6 +79,22 @@ export default Vue.extend({
             type: 'application/rss+xml',
             title: title,
             href: `https://audioxide.com/feed/${this.slug}/`,
+          },
+        );
+        metaData.script.push(
+          {
+              type: 'application/ld+json',
+              json: {
+                  '@context': 'http://schema.org',
+                  '@type': 'CollectionPage',
+                  name: title,
+                  "speakable": {
+                      "@type": "SpeakableSpecification",
+                      "cssSelector": [".post-listing h2", ".post-link .info"]
+                  },
+                  publisher: audioxideStructuredData(),
+                  breadcrumb: generateBreadcrumbs(this.$route),
+              }
           },
         );
         break;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,7 +2,7 @@
   <main>
     <component :is="leadComponent" :post="leadPost" class="lead-post" />
     <div class="panel reviews">
-      <h3>Reviews (<nuxt-link to="reviews">See all<span class="sr-only">reviews</span></nuxt-link>)</h3>
+      <h3>Album Reviews (<nuxt-link to="reviews">See all<span class="sr-only">reviews</span></nuxt-link>)</h3>
       <div class="listing">
         <review-link v-for="(item, key) in reviews" :key="key" :post="item" image-size="xsmall" />
       </div>

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -162,6 +162,7 @@ export default Vue.extend({
                     '@type': 'Review',
                     headline: title,
                     description: metadata.summary || metadata.blurb || '',
+                    reviewBody: this.review.content,
                     datePublished,
                     dateModified,
                     author: metadata.author.authors.map(author => ({

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -191,30 +191,6 @@ export default Vue.extend({
                         "cssSelector": ["review-header__album", "review-header__artist", "review-sidebar__summary"]
                         },
                     publisher: audioxideStructuredData(),
-                    breadcrumb: {
-                        '@type': 'BreadcrumbList',
-                        'itemListElement': 
-                        [
-                            {
-                            '@type': 'ListItem',
-                            'position': 1,
-                            'item':
-                                {
-                                '@id': 'https://audioxide.com/reviews/',
-                                'name': 'Album Reviews'
-                                }
-                            },
-                            {
-                            '@type': 'ListItem',
-                            'position': 2,
-                            'item':
-                                {
-                                '@id': 'https://audioxide.com' + this.$route.path,
-                                'name': metadata.album
-                                }
-                            }
-                        ],
-                    }
                 }
             }];
         }

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -191,6 +191,30 @@ export default Vue.extend({
                         "cssSelector": ["review-header__album", "review-header__artist", "review-sidebar__summary"]
                         },
                     publisher: audioxideStructuredData(),
+                    breadcrumb: {
+                        '@type': 'BreadcrumbList',
+                        'itemListElement': 
+                        [
+                            {
+                            '@type': 'ListItem',
+                            'position': 1,
+                            'item':
+                                {
+                                '@id': 'https://audioxide.com/reviews/',
+                                'name': 'Reviews'
+                                }
+                            },
+                            {
+                            '@type': 'ListItem',
+                            'position': 2,
+                            'item':
+                                {
+                                '@id': 'https://audioxide.com' + this.$route.path,
+                                'name': metadata.album
+                                }
+                            }
+                        ],
+                    }
                 }
             }];
         }

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -201,7 +201,7 @@ export default Vue.extend({
                             'item':
                                 {
                                 '@id': 'https://audioxide.com/reviews/',
-                                'name': 'Reviews'
+                                'name': 'Album Reviews'
                                 }
                             },
                             {

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -162,7 +162,6 @@ export default Vue.extend({
                     '@type': 'Review',
                     headline: title,
                     description: metadata.summary || metadata.blurb || '',
-                    reviewBody: this.review.content,
                     datePublished,
                     dateModified,
                     author: metadata.author.authors.map(author => ({

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -92,7 +92,7 @@ import Vue from 'vue';
 import PostContentBlock from '../../components/PostContentBlock.vue';
 import NewsletterSignup from '../../components/NewsletterSignup.vue';
 import RelatedPosts from '@/components/RelatedPosts.vue';
-import { albumCoverAlt, audioxideStructuredData, metaTitle, padNum, resolveAuthorLink } from '~/assets/utilities';
+import { albumCoverAlt, audioxideStructuredData, generateBreadcrumbs, metaTitle, padNum, resolveAuthorLink } from '~/assets/utilities';
 import { MetaInfo } from 'vue-meta';
 import formatISO from 'date-fns/formatISO';
 
@@ -107,8 +107,8 @@ export default Vue.extend({
     }),
     head() {
         const metadata = this.review.metadata;
-        const albumArtist = metadata ? `: ${metadata.album} // ${metadata.artist}` : '';
-        const title = metaTitle(`Review${albumArtist}`);
+        const albumArtist = metadata ? `${metadata.album} // ${metadata.artist}` : '';
+        const title = metaTitle(`Review${albumArtist && ': ' + albumArtist}`);
         const imgAlt = this.coverAlt;
         const pageMeta: MetaInfo = { title };
 
@@ -188,9 +188,10 @@ export default Vue.extend({
                     "speakable":
                         {
                         "@type": "SpeakableSpecification",
-                        "cssSelector": ["review-header__album", "review-header__artist", "review-sidebar__summary"]
+                        "cssSelector": [".review-header__album", ".review-header__artist", ".review-sidebar__summary"]
                         },
                     publisher: audioxideStructuredData(),
+                    breadcrumb: generateBreadcrumbs(this.$route, ["Album Reviews", albumArtist]),
                 }
             }];
         }

--- a/pages/reviews/index.vue
+++ b/pages/reviews/index.vue
@@ -6,22 +6,40 @@
 import Vue, { VNode } from 'vue';
 import PostListing from '@/components/PostListing.vue';
 import ReviewLink from '~/components/ReviewLink.vue';
-import { metaTitle } from '~/assets/utilities';
+import { audioxideStructuredData, generateBreadcrumbs, metaTitle } from '~/assets/utilities';
 
 export default Vue.extend({
     name: 'ReviewListing',
     components: { PostListing },
-    head: () => ({
-        title: metaTitle('Reviews'),
-        link: [
-            {
-                rel: 'alternative',
-                type: 'application/rss+xml',
-                title: metaTitle('Reviews'),
-                href: 'https://audioxide.com/feed/reviews/',
-            },
-        ],
-    }),
+    head() {
+        return {
+            title: metaTitle('Reviews'),
+            link: [
+                {
+                    rel: 'alternative',
+                    type: 'application/rss+xml',
+                    title: metaTitle('Reviews'),
+                    href: 'https://audioxide.com/feed/reviews/',
+                },
+            ],
+            script: [
+                {
+                    type: 'application/ld+json',
+                    json: {
+                        '@context': 'http://schema.org',
+                        '@type': 'CollectionPage',
+                        name: 'Reviews',
+                        "speakable": {
+                            "@type": "SpeakableSpecification",
+                            "cssSelector": [".post-listing h2", ".post-link .info"]
+                        },
+                        publisher: audioxideStructuredData(),
+                        breadcrumb: generateBreadcrumbs(this.$route),
+                    }
+                },
+            ]
+        };
+    },
     data: () => ({
         linkType: ReviewLink,
     }),

--- a/pages/tags/_tag.vue
+++ b/pages/tags/_tag.vue
@@ -6,6 +6,7 @@
 import Vue from 'vue';
 import PostListing from '@/components/PostListing.vue';
 import AnyPostLink from '@/components/AnyPostLink.vue';
+import { audioxideStructuredData, generateBreadcrumbs } from '~/assets/utilities';
 
 const tagFromParam = (tagParam: string) => tagParam.replace(/-/g, ' ');
 
@@ -28,7 +29,23 @@ export default Vue.extend({
     head() {
       return {
         meta: [
-          { name: "robots", content: "noindex,follow" }
+          { name: "robots", content: "noindex,follow" },
+        ],
+        script: [
+            {
+                type: 'application/ld+json',
+                json: {
+                    '@context': 'http://schema.org',
+                    '@type': 'CollectionPage',
+                    name: this.title,
+                    "speakable": {
+                        "@type": "SpeakableSpecification",
+                        "cssSelector": [".post-listing h2", ".post-link .info"]
+                    },
+                    publisher: audioxideStructuredData(),
+                    breadcrumb: generateBreadcrumbs(this.$route, [null, this.title]),
+                }
+            },
         ]
       }
     },


### PR DESCRIPTION
In hindsight it was really dumb to make one branch for all the stuff I wanted to do. That's what projects are for. I've separated some fairly routine changes into their own branch so they're ready to merge. 

- Site description adjusted
- Array bug fix in nux.config.js
- Featured image schema for articles
- Changed 'Reviews' to 'Album Reviews' on homepage
- Breadcrumbs added to review schema

Nothing major but figured it'd be nice to role them out while Search Console is updating its index of the site. Breadcrumbs were something WP took care of without me realising so I've added them to reviews. Articles will be tricker given the range of content types so I've left that alone for now.

Rich Results Test seems happy enough with the changes:

![image](https://user-images.githubusercontent.com/11380557/99887772-94761980-2c47-11eb-9af1-ec91d1755019.png)
