### PR TITLE
[Ready for review] Added trailing link to canonical urls

### DIFF
--- a/generateRoutes.js
+++ b/generateRoutes.js
@@ -13,10 +13,10 @@ module.exports = async () => {
     const routes = ['/'];
     const [types, tags] = await Promise.all([getData('types'), getData('tags')]);
     types.pages.forEach(route => routes.push(`/${route}/`));
-    tags.forEach(tag => routes.push(`/tags/${tag.replace(/ /g, '-')}`));
+    tags.forEach(tag => routes.push(`/tags/${tag.replace(/ /g, '-')}/`));
     await Promise.all(
         types.postTypes
-            .map(type => routes.push(`/${type}`) && getData(type)
+            .map(type => routes.push(`/${type}/`) && getData(type)
                 .then(posts => posts
                     .forEach(({ metadata: { type, slug } }) => routes.push(`/${type}/${slug}/`)),
                 ),

--- a/generateRoutes.js
+++ b/generateRoutes.js
@@ -12,13 +12,13 @@ module.exports = async () => {
     if (fs.existsSync(cacheFilePath)) return JSON.parse(await fs.promises.readFile(cacheFilePath));
     const routes = ['/'];
     const [types, tags] = await Promise.all([getData('types'), getData('tags')]);
-    types.pages.forEach(route => routes.push(`/${route}`));
+    types.pages.forEach(route => routes.push(`/${route}/`));
     tags.forEach(tag => routes.push(`/tags/${tag.replace(/ /g, '-')}`));
     await Promise.all(
         types.postTypes
             .map(type => routes.push(`/${type}`) && getData(type)
                 .then(posts => posts
-                    .forEach(({ metadata: { type, slug } }) => routes.push(`/${type}/${slug}`)),
+                    .forEach(({ metadata: { type, slug } }) => routes.push(`/${type}/${slug}/`)),
                 ),
             ),
     );

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -31,7 +31,7 @@ export default {
         { hid: "og:url", property: "og:url", content: SITE_URL + this.$route.path },
       ],
       link: [
-        { hid: "canonical", rel: "canonical", href: SITE_URL + this.$route.path },
+        { hid: "canonical", rel: "canonical", href: SITE_URL + this.$route.path + '/' },
       ]
     }
   },

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -31,7 +31,7 @@ export default {
         { hid: "og:url", property: "og:url", content: SITE_URL + this.$route.path },
       ],
       link: [
-        { hid: "canonical", rel: "canonical", href: SITE_URL + this.$route.path + '/' },
+        { hid: "canonical", rel: "canonical", href: SITE_URL + this.$route.path },
       ]
     }
   },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -13,7 +13,7 @@ const {
 
 const routes = fs.existsSync('./routes.json') ? JSON.parse(fs.readFileSync('./routes.json')) : ['/'];
 
-const routeDepth = (urlPath) => urlPath.replace(/[^/]+/g, '').length;
+const routeDepth = (urlPath) => urlPath.replace(/[^/]+/g, '').length - 1;
 
 const routePriority = (urlPath) => {
   if (urlPath === '/') return 1;

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -157,7 +157,7 @@ export default {
     plugins: [
       new SitemapPlugin({
         base: SITE_URL,
-        paths: routes.map(urlPath => ({
+        paths: routes.filter(urlPath => !urlPath.startsWith('/tags/')).map(urlPath => ({
           path: urlPath,
           lastMod: true,
           priority: routePriority(urlPath),


### PR DESCRIPTION
This may be part of the post-launch search turbulence ([though probably not](https://support.google.com/webmasters/thread/6354638?hl=en)). Our sitemap includes trailing slashes in its links while our canonical links do not. Not ideal but simple enough to fix. We just need to choose a site-wide standard and stick to it. I'm leaning trailing slash as I think that was the case on WP but open to either approach, so long as we're consistent. If nothing else it's nice to be tidy.

**Sitemap:**
![image](https://user-images.githubusercontent.com/11380557/100292274-4717e600-2f80-11eb-9dd4-0b3622ac96f7.png)

**Page reports:**
![image](https://user-images.githubusercontent.com/11380557/100292216-1fc11900-2f80-11eb-9533-9b75010c8634.png)