### PR TITLE
Video and artwork container classes for article content

### DIFF
--- a/components/AudioxideFooter.vue
+++ b/components/AudioxideFooter.vue
@@ -8,9 +8,10 @@
                 <li class="site-foot_nav-item site-foot_nav-item--icon site-foot_nav-item--twitter site-foot_nav-item--left"><span>Twitter</span><a :href="TWITTER_URL" aria-label="Twitter"><icon :icon="['fab', 'twitter']" /></a></li>
                 <li class="site-foot_nav-item site-foot_nav-item--icon site-foot_nav-item--instagram"><span>Instagram</span><a :href="INSTAGRAM_URL" aria-label="Instagram"><icon :icon="['fab', 'instagram']" /></a></li>
                 <li class="site-foot_nav-item site-foot_nav-item--icon site-foot_nav-item--rss"><span>RSS feed</span><a :href="RSS_BASE" aria-label="RSS feed"><icon icon="rss" /></a></li>
-                <li class="site-foot_nav-item"><nuxt-link to="/about">About</nuxt-link></li>
+                <li class="site-foot_nav-item"><nuxt-link to="/about/">About</nuxt-link></li>
                 <li class="site-foot_nav-item"><a :href="NEWSLETTER_URL">Newsletter</a></li>
-                <li class="site-foot_nav-item"><nuxt-link to="/contact">Contact</nuxt-link></li>
+                <li class="site-foot_nav-item"><nuxt-link to="/privacy/">Privacy</nuxt-link></li>
+                <li class="site-foot_nav-item"><nuxt-link to="/contact/">Contact</nuxt-link></li>
             </ul>
         </nav>
         <p class="copyright-jargon">&copy; {{ SITE_FOUNDING_YEAR }}-{{ year }}. All rights reserved.</p>
@@ -80,7 +81,7 @@ export default {
 
     .site-foot_nav-item {
         order: 2;
-        width: calc(100% / 3);
+        width: calc(100% / 4);
         margin-top: 1em;
         &.site-foot_nav-item--middle {
             order: 1;

--- a/components/PostContent.vue
+++ b/components/PostContent.vue
@@ -132,11 +132,14 @@ export default Vue.extend({
                 border: 1px solid #dddddd;
             }
             .video-container {
+                @include medium {
+                    padding-bottom: 37.6875%;
+                }
                 position: relative;
                 padding-bottom: 56.25%; /* 16:9 */
                 height: 0;
-                margin-top: $site-content__spacer--large;
-                margin-bottom: $site-content__spacer--large;
+                margin-top: $site-content__spacer--x-large;
+                margin-bottom: $site-content__spacer--x-large;
                 margin: 0 auto;
             }
             .video-container iframe {

--- a/components/PostContent.vue
+++ b/components/PostContent.vue
@@ -183,11 +183,10 @@ export default Vue.extend({
                 p, img, h2, h3, h4, blockquote, ul, hr {
                     width: 67%;
                 }
-            }
-
-            & .video-container {
+                .video-container {
                 width: 67%;
                 margin: auto;
+            }
             }
 
             & .pull-right {

--- a/components/PostContent.vue
+++ b/components/PostContent.vue
@@ -128,6 +128,9 @@ export default Vue.extend({
                 padding-right: 15px;
                 font-size: $site-content__font--small;
             }
+            .article-album-image {
+                border: 1px solid #dddddd;
+            }
             .video-container {
                 position: relative;
                 padding-bottom: 56.25%; /* 16:9 */

--- a/components/PostContent.vue
+++ b/components/PostContent.vue
@@ -185,6 +185,11 @@ export default Vue.extend({
                 }
             }
 
+            &. .video-container {
+                width: 67%;
+                margin: auto;
+            }
+
             & .pull-right {
                 float: right;
                 margin-right: -25%;

--- a/components/PostContent.vue
+++ b/components/PostContent.vue
@@ -185,7 +185,7 @@ export default Vue.extend({
                 }
             }
 
-            &. .video-container {
+            & .video-container {
                 width: 67%;
                 margin: auto;
             }

--- a/components/PostContent.vue
+++ b/components/PostContent.vue
@@ -135,6 +135,8 @@ export default Vue.extend({
                 position: relative;
                 padding-bottom: 56.25%; /* 16:9 */
                 height: 0;
+                margin-top: $site-content__spacer--large;
+                margin-bottom: $site-content__spacer--large;
             }
             .video-container iframe {
                 position: absolute;

--- a/components/PostContent.vue
+++ b/components/PostContent.vue
@@ -180,7 +180,7 @@ export default Vue.extend({
     @include medium {
         .decorate.content ::v-deep {
             & > {
-                p, img, h2, h3, h4, blockquote, ul, hr {
+                p, img, h2, h3, h4, blockquote, ul, hr, .video-container {
                     width: 67%;
                 }
             }

--- a/components/PostContent.vue
+++ b/components/PostContent.vue
@@ -132,6 +132,7 @@ export default Vue.extend({
                 position: relative;
                 padding-bottom: 56.25%; /* 16:9 */
                 height: 0;
+                margin: auto;
             }
             .video-container iframe {
                 position: absolute;
@@ -180,13 +181,9 @@ export default Vue.extend({
     @include medium {
         .decorate.content ::v-deep {
             & > {
-                p, img, h2, h3, h4, blockquote, ul, hr {
+                p, img, h2, h3, h4, blockquote, ul, hr, .video-container {
                     width: 67%;
                 }
-                .video-container {
-                width: 67%;
-                margin: auto;
-            }
             }
 
             & .pull-right {

--- a/components/PostContent.vue
+++ b/components/PostContent.vue
@@ -137,6 +137,7 @@ export default Vue.extend({
                 height: 0;
                 margin-top: $site-content__spacer--large;
                 margin-bottom: $site-content__spacer--large;
+                margin: 0 auto;
             }
             .video-container iframe {
                 position: absolute;

--- a/components/PostContent.vue
+++ b/components/PostContent.vue
@@ -128,6 +128,18 @@ export default Vue.extend({
                 padding-right: 15px;
                 font-size: $site-content__font--small;
             }
+            .video-container {
+                position: relative;
+                padding-bottom: 56.25%; /* 16:9 */
+                height: 0;
+            }
+            .video-container iframe {
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+            }
             hr {
                 @include hr-line-styles;
                 margin-top: $site-content__spacer--x-large;

--- a/components/PostContent.vue
+++ b/components/PostContent.vue
@@ -140,7 +140,8 @@ export default Vue.extend({
                 height: 0;
                 margin-top: $site-content__spacer--x-large;
                 margin-bottom: $site-content__spacer--x-large;
-                margin: 0 auto;
+                margin-left: auto;
+                margin-right: auto;
             }
             .video-container iframe {
                 position: absolute;

--- a/components/PostContent.vue
+++ b/components/PostContent.vue
@@ -132,7 +132,6 @@ export default Vue.extend({
                 position: relative;
                 padding-bottom: 56.25%; /* 16:9 */
                 height: 0;
-                margin: auto;
             }
             .video-container iframe {
                 position: absolute;
@@ -181,7 +180,7 @@ export default Vue.extend({
     @include medium {
         .decorate.content ::v-deep {
             & > {
-                p, img, h2, h3, h4, blockquote, ul, hr, .video-container {
+                p, img, h2, h3, h4, blockquote, ul, hr {
                     width: 67%;
                 }
             }


### PR DESCRIPTION
Attempt to clean up awkward embedded video appearance on articles.

Trying this approach: https://stackoverflow.com/questions/35814653/automatic-height-when-embedding-a-youtube-video

Got halfway there I think but struggling to make the container match the width of post content on tablet and desktop. Possibly some connection to the pull-right/left issue we spoke about @andrewbridge?

---

I've also moved over the grey outline image class as I continue to untangle myself from the catch-all post-launch patch. Means we won't have light album artwork blending with white backgrounds.

![image](https://user-images.githubusercontent.com/11380557/100557349-e30b5f80-32a8-11eb-9536-a481874e5632.png)

Ten minutes reformatting the data and we'll be right as rain.