### PR TITLE
Use server hooks to pre-render album banner

### DIFF
--- a/components/AlbumBanner.vue
+++ b/components/AlbumBanner.vue
@@ -14,13 +14,6 @@ import Vue from 'vue';
 
 export default Vue.extend({
     name: 'AlbumBanner',
-    async created() {
-        // Add in an API endpoint that allows us to check if we have all the reviews
-        // if (!store.state.posts.posts.reviews) {
-            await this.$store.dispatch('getBannerData');
-        // }
-        return true;
-    },
     computed: {
         bannerData(): PostListing<Review> {
             return this.$store.state.banner;
@@ -52,13 +45,14 @@ export default Vue.extend({
 
     .album-banner__art-wrapper {
         position: relative;
-        max-height: 200px;
-        height: calc(100vw / 4);
+        display: block;
+        height: 100%;
+        width: calc(100% / 4);
         @include small {
-            height: calc(100vw / 6);
+            width: calc(100% / 6);
         }
         @include medium {
-            height: calc(100vw / 11);
+            width: calc(100% / 11);
         }
         @media (max-width: $bp_small - .1) {
             &:nth-child(4) ~ .album-banner__art-wrapper {

--- a/store/index.js
+++ b/store/index.js
@@ -30,7 +30,7 @@ export const plugins = [
 export const state = () => ({
     types: {},
     pages: {},
-    banner: {},
+    banner: [],
     breakpoint: 'base',
 });
 
@@ -50,6 +50,9 @@ export const mutations = {
 };
 
 export const actions = {
+    async nuxtServerInit({ dispatch }) {
+        await dispatch('getBannerData');
+    },
     async getBannerData({ commit }) {
         commit('setBannerData', await banner());
     },


### PR DESCRIPTION
Fixes #111 

This was actually occurring due to the album banner lazy loading. I have rejigged the the CSS to stop a reflow after the image loads and set some more sensible sizing, but I think the pre-rendering is the missing piece.