### PR TITLE
Added 'font-display: swap;' to fonts

### DIFF
--- a/assets/styles/fonts.scss
+++ b/assets/styles/fonts.scss
@@ -5,6 +5,7 @@
     font-family: 'Spectral SC';
     font-style: normal;
     font-weight: 500;
+    font-display: swap;
     src: local('Spectral SC Medium'), local('SpectralSC-Medium'),
          url('~assets/webfonts/Spectral_SC/spectral-sc-v5-latin-500.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
          url('~assets/webfonts/Spectral_SC/spectral-sc-v5-latin-500.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -14,6 +15,7 @@
     font-family: 'Spectral SC';
     font-style: italic;
     font-weight: 500;
+    font-display: swap;
     src: local('Spectral SC Medium Italic'), local('SpectralSC-MediumItalic'),
          url('~assets/webfonts/Spectral_SC/spectral-sc-v5-latin-500italic.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
          url('~assets/webfonts/Spectral_SC/spectral-sc-v5-latin-500italic.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -24,6 +26,7 @@
     font-family: 'Spectral';
     font-style: normal;
     font-weight: 200;
+    font-display: swap;
     src: local('Spectral ExtraLight'), local('Spectral-ExtraLight'),
          url('~assets/webfonts/Spectral/spectral-v6-latin-200.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
          url('~assets/webfonts/Spectral/spectral-v6-latin-200.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -33,6 +36,7 @@
     font-family: 'Spectral';
     font-style: italic;
     font-weight: 200;
+    font-display: swap;
     src: local('Spectral ExtraLight Italic'), local('Spectral-ExtraLightItalic'),
          url('~assets/webfonts/Spectral/spectral-v6-latin-200italic.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
          url('~assets/webfonts/Spectral/spectral-v6-latin-200italic.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -42,6 +46,7 @@
     font-family: 'Spectral';
     font-style: normal;
     font-weight: 400;
+    font-display: swap;
     src: local('Spectral Regular'), local('Spectral-Regular'),
          url('~assets/webfonts/Spectral/spectral-v6-latin-regular.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
          url('~assets/webfonts/Spectral/spectral-v6-latin-regular.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -51,6 +56,7 @@
     font-family: 'Spectral';
     font-style: italic;
     font-weight: 400;
+    font-display: swap;
     src: local('Spectral Italic'), local('Spectral-Italic'),
          url('~assets/webfonts/Spectral/spectral-v6-latin-italic.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
          url('~assets/webfonts/Spectral/spectral-v6-latin-italic.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -60,6 +66,7 @@
     font-family: 'Spectral';
     font-style: normal;
     font-weight: 600;
+    font-display: swap;
     src: local('Spectral SemiBold'), local('Spectral-SemiBold'),
          url('~assets/webfonts/Spectral/spectral-v6-latin-600.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
          url('~assets/webfonts/Spectral/spectral-v6-latin-600.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -69,6 +76,7 @@
     font-family: 'Spectral';
     font-style: italic;
     font-weight: 600;
+    font-display: swap;
     src: local('Spectral SemiBold Italic'), local('Spectral-SemiBoldItalic'),
          url('~assets/webfonts/Spectral/spectral-v6-latin-600italic.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
          url('~assets/webfonts/Spectral/spectral-v6-latin-600italic.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -79,6 +87,7 @@
     font-family: 'Source Sans Pro';
     font-style: normal;
     font-weight: 400;
+    font-display: swap;
     src: local('Source Sans Pro Regular'), local('SourceSansPro-Regular'),
          url('~assets/webfonts/Source_Sans_Pro/source-sans-pro-v14-latin-regular.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
          url('~assets/webfonts/Source_Sans_Pro/source-sans-pro-v14-latin-regular.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -88,6 +97,7 @@
     font-family: 'Source Sans Pro';
     font-style: italic;
     font-weight: 400;
+    font-display: swap;
     src: local('Source Sans Pro Italic'), local('SourceSansPro-Italic'),
          url('~assets/webfonts/Source_Sans_Pro/source-sans-pro-v14-latin-italic.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
          url('~assets/webfonts/Source_Sans_Pro/source-sans-pro-v14-latin-italic.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -97,6 +107,7 @@
     font-family: 'Source Sans Pro';
     font-style: italic;
     font-weight: 600;
+    font-display: swap;
     src: local('Source Sans Pro SemiBold Italic'), local('SourceSansPro-SemiBoldItalic'),
          url('~assets/webfonts/Source_Sans_Pro/source-sans-pro-v14-latin-600italic.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
          url('~assets/webfonts/Source_Sans_Pro/source-sans-pro-v14-latin-600italic.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -106,6 +117,7 @@
     font-family: 'Source Sans Pro';
     font-style: normal;
     font-weight: 600;
+    font-display: swap;
     src: local('Source Sans Pro SemiBold'), local('SourceSansPro-SemiBold'),
          url('~assets/webfonts/Source_Sans_Pro/source-sans-pro-v14-latin-600.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
          url('~assets/webfonts/Source_Sans_Pro/source-sans-pro-v14-latin-600.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */


### PR DESCRIPTION
PageSpeed Insights flagged this as a problem and it seemed simple enough to fix. Prevents there being empty space where words should be while our fonts are loading.

**Source:** https://web.dev/font-display/

May be a coincidence but First Contentful Paint seems a lot faster on the preview. I'll also propose a change to our licenced font to complete the set. 