### PR TITLE
[Ready for review] Album artwork credits

### DIFF
--- a/assets/utilities.ts
+++ b/assets/utilities.ts
@@ -139,7 +139,7 @@ const generateBreadcrumbs = (route: Route, titles: Array<string | null> = []) =>
 });
 
 const toggleArtworkCredit = () => {
-    const artToggle = document.getElementById("review-sidebar__artwork-info");
+    const artToggle = document.getElementById("review-sidebar__artwork-info")!;
         if (artToggle.style.display === "none") {
             artToggle.style.display = "block";
         } else {

--- a/assets/utilities.ts
+++ b/assets/utilities.ts
@@ -138,6 +138,15 @@ const generateBreadcrumbs = (route: Route, titles: Array<string | null> = []) =>
     })),
 });
 
+const toggleArtworkCredit = () => {
+    const artToggle = document.getElementById("review-sidebar__artwork-info");
+        if (artToggle.style.display === "none") {
+            artToggle.style.display = "block";
+        } else {
+            artToggle.style.display = "none";
+        }
+}; 
+
 export {
     rand,
     padNum,
@@ -150,4 +159,5 @@ export {
     authorDivider,
     audioxideStructuredData,
     generateBreadcrumbs,
+    toggleArtworkCredit,
 }

--- a/assets/utilities.ts
+++ b/assets/utilities.ts
@@ -140,7 +140,7 @@ const generateBreadcrumbs = (route: Route, titles: Array<string | null> = []) =>
 
 const toggleArtworkCredit = () => {
     const artToggle = document.getElementById("review-sidebar__artwork-info")!;
-        if (artToggle.style.display === "none") {
+        if (!artToggle.style.display || artToggle.style.display === "none") {
             artToggle.style.display = "block";
         } else {
             artToggle.style.display = "none";

--- a/assets/utilities.ts
+++ b/assets/utilities.ts
@@ -138,15 +138,6 @@ const generateBreadcrumbs = (route: Route, titles: Array<string | null> = []) =>
     })),
 });
 
-const toggleArtworkCredit = () => {
-    const artToggle = document.getElementById("review-sidebar__artwork-info")!;
-        if (!artToggle.style.display || artToggle.style.display === "none") {
-            artToggle.style.display = "block";
-        } else {
-            artToggle.style.display = "none";
-        }
-}; 
-
 export {
     rand,
     padNum,
@@ -159,5 +150,4 @@ export {
     authorDivider,
     audioxideStructuredData,
     generateBreadcrumbs,
-    toggleArtworkCredit,
 }

--- a/components/Icon.vue
+++ b/components/Icon.vue
@@ -28,7 +28,7 @@
     faRss,
     faSearch,
     faBrain,
-    faInfoCircle
+    faInfoCircle,
     faSpinnerThird,
   });
 

--- a/components/Icon.vue
+++ b/components/Icon.vue
@@ -7,6 +7,7 @@
     faRss,
     faSearch,
     faBrain,
+    faInfoCircle,
   } from '@fortawesome/free-solid-svg-icons';
   import {
     faFacebookF,
@@ -27,6 +28,7 @@
     faRss,
     faSearch,
     faBrain,
+    faInfoCircle
     faSpinnerThird,
   });
 

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -40,7 +40,7 @@
             <figure>
             <img class="review-sidebar__album-cover" :alt="coverAlt" :src="review.metadata.featuredimage['medium-square']" :style="sidebarStyles" width="600" height="600" />
                 <template v-if="review.metadata.artworkCredit">
-                <figcaption class="review-sidebar__artwork-info">The album artwork of <i>{{ review.metadata.album }}<i/> by {{ review.metadata.artist }} {{ review.metadata.artworkCredit }} [<a :href="review.metadata.artworkCreditSource" target="_blank" rel="noopener">Source</a>]</figcaption>
+                <figcaption class="review-sidebar__artwork-info">The album artwork of <i>{{ review.metadata.album }}</i> by {{ review.metadata.artist }} {{ review.metadata.artworkCredit }} [<a :href="review.metadata.artworkCreditSource" target="_blank" rel="noopener">Source</a>]</figcaption>
                 <span class="review-sidebar__artwork-info-icon"><icon @click="toggleArtworkCredit" icon="info-circle" /></span>
             </template>
             </figure>

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -352,6 +352,10 @@ export default Vue.extend({
         font-size: 0.9em;
     }
 
+    .review-sidebar__artwork-info i {
+        font-style: italic;
+    }
+
     .review-sidebar__artwork-info-icon {
         color: lightgray;
         margin: 1em;

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -38,12 +38,12 @@
                     <img class="review-sidebar__ribbon" src="~assets/img/ribbon-bronze.png" alt="Bronze Audioxide review ribbon">
                 </template>
             <figure>
-            <img class="review-sidebar__album-cover" :alt="coverAlt" :src="review.metadata.featuredimage['medium-square']" :style="sidebarStyles" width="600" height="600" />
+                <img class="review-sidebar__album-cover" :alt="coverAlt" :src="review.metadata.featuredimage['medium-square']" :style="sidebarStyles" width="600" height="600" />
                 <template v-if="review.metadata.artworkCredit">
-                <figcaption id="review-sidebar__artwork-info">The album artwork of <i>{{ review.metadata.album }}</i> by {{ review.metadata.artist }} {{ review.metadata.artworkCredit }}<template v-if="review.metadata.artworkCreditSource"> [<a :href="review.metadata.artworkCreditSource" target="_blank" rel="noopener">Source</a>]</template>
-                </figcaption>
-                <icon class="review-sidebar__artwork-info-icon" @click="toggleArtworkCredit" icon="info-circle" />
-            </template>
+                    <figcaption class="review-sidebar__artwork-info" v-if="showCredit">The album artwork of <i>{{ review.metadata.album }}</i> by {{ review.metadata.artist }} {{ review.metadata.artworkCredit }}<template v-if="review.metadata.artworkCreditSource"> [<a :href="review.metadata.artworkCreditSource" target="_blank" rel="noopener">Source</a>]</template>
+                    </figcaption>
+                    <icon class="review-sidebar__artwork-info-icon" @click="showCredit = !showCredit" icon="info-circle" />
+                </template>
             </figure>
             </div>
             <div class="review-sidebar__total-score" :style="sidebarStyles">
@@ -96,7 +96,7 @@ import Vue from 'vue';
 import PostContentBlock from '../../components/PostContentBlock.vue';
 import NewsletterSignup from '../../components/NewsletterSignup.vue';
 import RelatedPosts from '@/components/RelatedPosts.vue';
-import { albumCoverAlt, audioxideStructuredData, generateBreadcrumbs, metaTitle, padNum, resolveAuthorLink, authorDivider, toggleArtworkCredit  } from '~/assets/utilities';
+import { albumCoverAlt, audioxideStructuredData, generateBreadcrumbs, metaTitle, padNum, resolveAuthorLink, authorDivider  } from '~/assets/utilities';
 import { MetaInfo } from 'vue-meta';
 import formatISO from 'date-fns/formatISO';
 
@@ -108,6 +108,7 @@ export default Vue.extend({
     components: { PostContentBlock, NewsletterSignup, RelatedPosts },
     data: () => ({
         review: {} as Review,
+        showCredit: false,
     }),
     head() {
         const metadata = this.review.metadata;
@@ -250,7 +251,6 @@ export default Vue.extend({
     },
     methods: {
         authorDivider,
-        toggleArtworkCredit,
     }
 })
 </script>
@@ -340,12 +340,11 @@ export default Vue.extend({
         border-top: 0;
     }
 
-    #review-sidebar__artwork-info {
+    .review-sidebar__artwork-info {
         font-family: 'Source Sans Pro', sans-serif;
         position: absolute;
         bottom:0;
         left:0;
-        display: none;
         padding: 5% 20% 5% 5%;
         opacity: 0.75;
         color: white;
@@ -353,6 +352,8 @@ export default Vue.extend({
         line-height: 1.3;
         font-size: 0.9em;
         margin: 1px;
+        max-height: 100%;
+        overflow-y: scroll;
     }
 
     .review-sidebar__artwork-info i {

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -352,8 +352,6 @@ export default Vue.extend({
         line-height: 1.3;
         font-size: 0.9em;
         margin: 1px;
-        max-height: 100%;
-        overflow-y: scroll;
     }
 
     .review-sidebar__artwork-info .album {

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -351,6 +351,7 @@ export default Vue.extend({
         background-color: black;
         line-height: 1.3;
         font-size: 0.9em;
+        margin: 1px;
     }
 
     .review-sidebar__artwork-info i {
@@ -359,9 +360,9 @@ export default Vue.extend({
 
     .review-sidebar__artwork-info-icon {
         color: gray;
-        margin: 1em;
-        width: 2em;
-        height: 2em;
+        margin: 8%;
+        width: 12%;
+        height: 12%;
         position: absolute;
         bottom: 0;
         right: 0;

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -39,7 +39,10 @@
                 </template>
             <figure>
             <img class="review-sidebar__album-cover" :alt="coverAlt" :src="review.metadata.featuredimage['medium-square']" :style="sidebarStyles" width="600" height="600" />
-            <figcaption class="review-sidebar__album-info">{ { review.featured_media.description } }</figcaption>
+                <template v-if="review.metadata.artworkCredit">
+                <figcaption class="review-sidebar__artwork-info">The album artwork of <i>{{ review.metadata.album }}<i/> by {{ review.metadata.artist }} {{ review.metadata.artworkCredit }} [<a :href="review.metadata.artworkCreditSource" target="_blank" rel="noopener">Source</a>]</figcaption>
+                <span class="review-sidebar__artwork-info-icon"><icon @click="toggleArtworkCredit" icon="info-circle" /></span>
+            </template>
             </figure>
             </div>
             <div class="review-sidebar__total-score" :style="sidebarStyles">
@@ -335,8 +338,28 @@ export default Vue.extend({
         border-top: 0;
     }
 
-    .review-sidebar__album-info {
-        display: none;
+    .review-sidebar__artwork-info {
+        font-family: 'Source Sans Pro', sans-serif;
+        position: absolute;
+        bottom:0;
+        left:0;
+        // display: none;
+        padding: 5% 20% 5% 5%;
+        opacity: 0.8;
+        color: white;
+        background-color: black;
+        line-height: 1.3;
+        font-size: 0.9em;
+    }
+
+    .review-sidebar__artwork-info-icon {
+        color: lightgray;
+        margin: 1em;
+        width: 2em;
+        height: 2em;
+        position: absolute;
+        bottom: 0;
+        right: 0;
     }
 
     .review-sidebar__total-score, .review-sidebar__tracks {

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -360,9 +360,9 @@ export default Vue.extend({
 
     .review-sidebar__artwork-info-icon {
         color: gray;
-        margin: 8%;
-        width: 12%;
-        height: 12%;
+        margin: 12%;
+        width: 8%;
+        height: 8%;
         position: absolute;
         bottom: 0;
         right: 0;

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -40,7 +40,8 @@
             <figure>
             <img class="review-sidebar__album-cover" :alt="coverAlt" :src="review.metadata.featuredimage['medium-square']" :style="sidebarStyles" width="600" height="600" />
                 <template v-if="review.metadata.artworkCredit">
-                <figcaption id="review-sidebar__artwork-info">The album artwork of <i>{{ review.metadata.album }}</i> by {{ review.metadata.artist }} {{ review.metadata.artworkCredit }} [<a :href="review.metadata.artworkCreditSource" target="_blank" rel="noopener">Source</a>]</figcaption>
+                <figcaption id="review-sidebar__artwork-info">The album artwork of <i>{{ review.metadata.album }}</i> by {{ review.metadata.artist }} {{ review.metadata.artworkCredit }}<template v-if="review.metadata.artworkCreditSource"> [<a :href="review.metadata.artworkCreditSource" target="_blank" rel="noopener">Source</a>]</template>
+                </figcaption>
                 <icon class="review-sidebar__artwork-info-icon" @click="toggleArtworkCredit" icon="info-circle" />
             </template>
             </figure>

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -346,7 +346,7 @@ export default Vue.extend({
         left:0;
         display: none;
         padding: 5% 20% 5% 5%;
-        opacity: 0.8;
+        opacity: 0.75;
         color: white;
         background-color: black;
         line-height: 1.3;

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -40,7 +40,7 @@
             <figure>
                 <img class="review-sidebar__album-cover" :alt="coverAlt" :src="review.metadata.featuredimage['medium-square']" :style="sidebarStyles" width="600" height="600" />
                 <template v-if="review.metadata.artworkCredit">
-                    <figcaption class="review-sidebar__artwork-info" v-if="showCredit">The album artwork of <i>{{ review.metadata.album }}</i> by {{ review.metadata.artist }} {{ review.metadata.artworkCredit }}<template v-if="review.metadata.artworkCreditSource"> [<a :href="review.metadata.artworkCreditSource" target="_blank" rel="noopener">Source</a>]</template>
+                    <figcaption class="review-sidebar__artwork-info" v-if="showCredit">The album artwork of <span class="album">{{ review.metadata.album }}</span> by {{ review.metadata.artist }} {{ review.metadata.artworkCredit }}<template v-if="review.metadata.artworkCreditSource"> [<a :href="review.metadata.artworkCreditSource" target="_blank" rel="noopener">Source</a>]</template>
                     </figcaption>
                     <icon class="review-sidebar__artwork-info-icon" @click="showCredit = !showCredit" icon="info-circle" />
                 </template>
@@ -96,7 +96,7 @@ import Vue from 'vue';
 import PostContentBlock from '../../components/PostContentBlock.vue';
 import NewsletterSignup from '../../components/NewsletterSignup.vue';
 import RelatedPosts from '@/components/RelatedPosts.vue';
-import { albumCoverAlt, audioxideStructuredData, generateBreadcrumbs, metaTitle, padNum, resolveAuthorLink, authorDivider  } from '~/assets/utilities';
+import { albumCoverAlt, audioxideStructuredData, generateBreadcrumbs, metaTitle, padNum, resolveAuthorLink, authorDivider } from '~/assets/utilities';
 import { MetaInfo } from 'vue-meta';
 import formatISO from 'date-fns/formatISO';
 
@@ -356,7 +356,7 @@ export default Vue.extend({
         overflow-y: scroll;
     }
 
-    .review-sidebar__artwork-info i {
+    .review-sidebar__artwork-info .album {
         font-style: italic;
     }
 

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -40,8 +40,8 @@
             <figure>
             <img class="review-sidebar__album-cover" :alt="coverAlt" :src="review.metadata.featuredimage['medium-square']" :style="sidebarStyles" width="600" height="600" />
                 <template v-if="review.metadata.artworkCredit">
-                <figcaption class="review-sidebar__artwork-info">The album artwork of <i>{{ review.metadata.album }}</i> by {{ review.metadata.artist }} {{ review.metadata.artworkCredit }} [<a :href="review.metadata.artworkCreditSource" target="_blank" rel="noopener">Source</a>]</figcaption>
-                <span class="review-sidebar__artwork-info-icon"><icon @click="toggleArtworkCredit" icon="info-circle" /></span>
+                <figcaption id="review-sidebar__artwork-info">The album artwork of <i>{{ review.metadata.album }}</i> by {{ review.metadata.artist }} {{ review.metadata.artworkCredit }} [<a :href="review.metadata.artworkCreditSource" target="_blank" rel="noopener">Source</a>]</figcaption>
+                <icon class="review-sidebar__artwork-info-icon" @click="toggleArtworkCredit" icon="info-circle" />
             </template>
             </figure>
             </div>
@@ -95,7 +95,7 @@ import Vue from 'vue';
 import PostContentBlock from '../../components/PostContentBlock.vue';
 import NewsletterSignup from '../../components/NewsletterSignup.vue';
 import RelatedPosts from '@/components/RelatedPosts.vue';
-import { albumCoverAlt, audioxideStructuredData, generateBreadcrumbs, metaTitle, padNum, resolveAuthorLink, authorDivider  } from '~/assets/utilities';
+import { albumCoverAlt, audioxideStructuredData, generateBreadcrumbs, metaTitle, padNum, resolveAuthorLink, authorDivider, toggleArtworkCredit  } from '~/assets/utilities';
 import { MetaInfo } from 'vue-meta';
 import formatISO from 'date-fns/formatISO';
 
@@ -249,6 +249,7 @@ export default Vue.extend({
     },
     methods: {
         authorDivider,
+        toggleArtworkCredit,
     }
 })
 </script>
@@ -338,12 +339,12 @@ export default Vue.extend({
         border-top: 0;
     }
 
-    .review-sidebar__artwork-info {
+    #review-sidebar__artwork-info {
         font-family: 'Source Sans Pro', sans-serif;
         position: absolute;
         bottom:0;
         left:0;
-        // display: none;
+        display: none;
         padding: 5% 20% 5% 5%;
         opacity: 0.8;
         color: white;
@@ -357,13 +358,17 @@ export default Vue.extend({
     }
 
     .review-sidebar__artwork-info-icon {
-        color: lightgray;
+        color: gray;
         margin: 1em;
         width: 2em;
         height: 2em;
         position: absolute;
         bottom: 0;
         right: 0;
+    }
+
+    .review-sidebar__artwork-info-icon:hover {
+        color: lightgray;
     }
 
     .review-sidebar__total-score, .review-sidebar__tracks {

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -360,7 +360,7 @@ export default Vue.extend({
 
     .review-sidebar__artwork-info-icon {
         color: gray;
-        margin: 12%;
+        margin: 8%;
         width: 8%;
         height: 8%;
         position: absolute;
@@ -370,6 +370,7 @@ export default Vue.extend({
 
     .review-sidebar__artwork-info-icon:hover {
         color: lightgray;
+        cursor: pointer;
     }
 
     .review-sidebar__total-score, .review-sidebar__tracks {


### PR DESCRIPTION
The post-launch patch untangling continues. Faffing around with styling so the credits look ok, then it should just be a case of inserting a simple function to toggle display on and off when readers click the info icon.

Current test reviews are _Fresh Fruit for Rotting Vegetables_ by Dead Kennedys and _To Bring You My Love_ by PJ Harvey. I think the data used for previews is old so the look isn't quite right, but what I've done is generate the opening ('The album artwork of `<i>`X`</i>` by Y...') then have the description follow on from it. That way we get to italicise the album title. 

This is working now, albeit clunkily. The italics did work then didn't again and I can't work out why. I _think_ that's the only remaining problem, aside from us being on the same page about formatting the data.
