### PR TITLE
[Ready for review] Backlink redirects, updated site info schema, table styling

### DIFF
--- a/assets/siteConstants.js
+++ b/assets/siteConstants.js
@@ -7,6 +7,7 @@ const SITE_FOUNDING_YEAR=2015;
 const RSS_BASE='/feed';
 const RSS_URL=SITE_URL + RSS_BASE;
 const NEWSLETTER_URL='https://eepurl.com/cox6qr';
+const GITHUB_URL='https://github.com/audioxide';
 
 // Social media
 const TWITTER_HANDLE='audioxide';
@@ -24,6 +25,7 @@ export {
     RSS_BASE,
     RSS_URL,
     NEWSLETTER_URL,
+    GITHUB_URL,
     TWITTER_HANDLE,
     TWITTER_URL,
     FACEBOOK_HANDLE,

--- a/assets/siteConstants.js
+++ b/assets/siteConstants.js
@@ -1,6 +1,6 @@
 const SITE_URL=process.env.SITE_URL || 'https://audioxide.com';
 const SITE_NAME='Audioxide';
-const SITE_DESCRIPTION='Three friends reviewing an album a week. Also publish articles, interviews, and other oddities when then mood takes them.';
+const SITE_DESCRIPTION='Three friends reviewing an album a week. Also publish articles, interviews, listening parties, and other oddities when the mood takes them.';
 const SITE_FOUNDING_YEAR=2015;
 
 // Content channels

--- a/assets/styles/reset.scss
+++ b/assets/styles/reset.scss
@@ -53,7 +53,11 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 }
-
+td, th {
+  border: 1px solid #f5f5f5;
+  padding: 0.5rem;
+  text-align: left;
+}
 input, textarea {
   font-size: 1rem;
   border: none;

--- a/assets/styles/reset.scss
+++ b/assets/styles/reset.scss
@@ -53,11 +53,6 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 }
-td, th {
-  border: 1px solid #f5f5f5;
-  padding: 0.5rem;
-  text-align: left;
-}
 input, textarea {
   font-size: 1rem;
   border: none;

--- a/assets/utilities.ts
+++ b/assets/utilities.ts
@@ -96,8 +96,8 @@ const audioxideStructuredData = () => ({
     '@type': 'WebSite',
     name: SITE_NAME,
     description: SITE_DESCRIPTION,
-    foundingDate: SITE_FOUNDING_YEAR.toString(),
-    founder: [
+    copyrightYear: SITE_FOUNDING_YEAR,
+    creator: [
         {
             '@type': 'Person',
             'name': 'André Dack',
@@ -115,7 +115,6 @@ const audioxideStructuredData = () => ({
         }
     ],
     url: SITE_URL,
-    logo: `${SITE_URL}/full-logo-black-on-white.png`,
     sameAs: [ FACEBOOK_URL, TWITTER_URL, INSTAGRAM_URL, GITHUB_URL ],
     isAccessibleForFree: true,
 });

--- a/assets/utilities.ts
+++ b/assets/utilities.ts
@@ -2,6 +2,7 @@ import { Route } from 'vue-router';
 import he from 'he';
 import {
     SITE_DESCRIPTION,
+    GITHUB_URL,
     TWITTER_URL,
     FACEBOOK_URL,
     INSTAGRAM_URL,
@@ -115,7 +116,7 @@ const audioxideStructuredData = () => ({
     ],
     url: SITE_URL,
     logo: `${SITE_URL}/full-logo-black-on-white.png`,
-    sameAs: [ FACEBOOK_URL, TWITTER_URL, INSTAGRAM_URL ],
+    sameAs: [ FACEBOOK_URL, TWITTER_URL, INSTAGRAM_URL, GITHUB_URL ],
 });
 
 const generateBreadcrumbs = (route: Route, titles: Array<string | null> = []) => ({

--- a/assets/utilities.ts
+++ b/assets/utilities.ts
@@ -93,7 +93,7 @@ const authorDivider = (key: number, length: number) => {
 
 const audioxideStructuredData = () => ({
     '@context': 'http://schema.org',
-    '@type': 'Organization',
+    '@type': 'WebSite',
     name: SITE_NAME,
     description: SITE_DESCRIPTION,
     foundingDate: SITE_FOUNDING_YEAR.toString(),
@@ -106,7 +106,7 @@ const audioxideStructuredData = () => ({
         {
             '@type': 'Person',
             'name': 'Andrew Bridge',
-            'sameAs': 'http://www.andrewhbridge.co.uk'
+            'sameAs': 'https://www.andrewhbridge.co.uk'
         },
         {
             '@type': 'Person',
@@ -117,6 +117,7 @@ const audioxideStructuredData = () => ({
     url: SITE_URL,
     logo: `${SITE_URL}/full-logo-black-on-white.png`,
     sameAs: [ FACEBOOK_URL, TWITTER_URL, INSTAGRAM_URL, GITHUB_URL ],
+    isAccessibleForFree: true,
 });
 
 const generateBreadcrumbs = (route: Route, titles: Array<string | null> = []) => ({

--- a/components/PostContent.vue
+++ b/components/PostContent.vue
@@ -133,6 +133,11 @@ export default Vue.extend({
                 margin-bottom: $site-content__spacer--x-large;
                 margin-left: auto;
                 margin-right: auto;
+                td, th {
+                    border: 1px solid $colour-grey;
+                    padding: 0.5rem;
+                    text-align: left;
+                }
             }
             .article-album-image {
                 border: 1px solid #dddddd;

--- a/components/PostContent.vue
+++ b/components/PostContent.vue
@@ -128,6 +128,12 @@ export default Vue.extend({
                 padding-right: 15px;
                 font-size: $site-content__font--small;
             }
+            table {
+                margin-top: $site-content__spacer--x-large;
+                margin-bottom: $site-content__spacer--x-large;
+                margin-left: auto;
+                margin-right: auto;
+            }
             .article-album-image {
                 border: 1px solid #dddddd;
             }
@@ -193,7 +199,7 @@ export default Vue.extend({
     @include medium {
         .decorate.content ::v-deep {
             & > {
-                p, img, h2, h3, h4, blockquote, ul, hr, .video-container {
+                p, img, h2, h3, h4, blockquote, ul, table, hr, .video-container {
                     width: 67%;
                 }
             }

--- a/netlify.toml
+++ b/netlify.toml
@@ -40,6 +40,14 @@
   to = "/reviews/marilyn-manson-heaven-upside-down"
 
 [[redirects]]
+  from = "/wp-content/uploads/2019/01/Soma-Spotify-main-image.png"
+  to = "/articles/soma-spotify-and-the-brave-new-world-of-music-consumption"
+
+[[redirects]]
+  from = "/wp-content/uploads/2017/08/vault-boy-shadow-1024x910.jpg"
+  to = "/articles/world-on-fire-the-music-of-fallout-3/"
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200


### PR DESCRIPTION
Almost all of our backlinks have carried over fine from migration, there were just a couple of images that needed redirecting. I've pointed the links to the article they feature in, rather than the image itself, to offset further changes. 

Unrelated, but I've also added our GitHub organisation to site constants and overall _Audioxide_ schema info.