### PR TITLE
Replace double quotes around review summaries with single quotes

### DIFF
--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -51,7 +51,7 @@
                 </span>
                 <span class="review-sidebar__total" :style="sidebarHighlightStyles">{{review.metadata.totalscore.possible}}</span>
             </div>
-            <p class="review-sidebar__summary" :style="textStyles">{{ review.metadata.summary }}</p>
+            <p class="review-sidebar__summary" :style="textStyles">‘{{ review.metadata.summary }}’</p>
             <div class="review-sidebar__tracks" :class="{ 'review-sidebar__tracks--artist-link': review.metadata.artistLink }" :style="sidebarStyles">
                 <template v-if="review.metadata.essentialtracks.length">
                 <p class="review-sidebar__heading" :style="sidebarHighlightStyles">Essential</p>
@@ -459,12 +459,6 @@ export default Vue.extend({
         margin: 0;
         font-style: italic;
         padding: $site-content__spacer--large;
-        &:before {
-            content: open-quote;
-        }
-        &:after {
-            content: close-quote;
-        }
     }
 
     .review-sidebar__tracks :first-child {


### PR DESCRIPTION
This occurred to me while doing a mockup for https://github.com/audioxide/website/issues/83. The 'house style' is that track names are in double quotes and actual quotes are in single quotes. That way there's no clash between the two.

With that in mind it makes sense for review summaries to be in single quotes too. Looks that little bit cleaner too, which is nice.

@andrewbridge I've put the quotes in the HTML rather than the CSS as it seems to be more than a purely cosmetic thing? Happy to be corrected there.