### PR TITLE
Give header black background

### DIFF
--- a/components/AudioxideHeader.vue
+++ b/components/AudioxideHeader.vue
@@ -20,5 +20,6 @@ export default {
 
   header {
     padding-top: $site-nav__bar-height;
+    background-color: black;
   }
 </style>


### PR DESCRIPTION
This has bugged me for yonks. On mobile devices when you get the elastic effect stretching the navbar from the album banner you get a white gap. This gives the overall navbar component a black background so it remains 'connected'.

I wasn't sure how to record/replicate the problem but here is a before and after of what's going on underneath the navbar:

![image](https://user-images.githubusercontent.com/11380557/140622361-41ae1d96-0fed-4229-b125-5da1c1ff67af.png)

![image](https://user-images.githubusercontent.com/11380557/140622367-498b8b8c-d7d3-4773-b45a-e692a831bfd9.png)
