### PR TITLE
Skip to main content link for more accessible navigation

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,7 +1,10 @@
 <template>
   <div>
+    <a class="skip-link" href="#main">Skip to main content</a>
     <audioxide-header />
-    <nuxt />
+    <div id="main">
+      <nuxt />
+    </div>
     <audioxide-footer />
   </div>
 </template>
@@ -114,5 +117,15 @@ export default {
     &::-webkit-details-marker {
       display: none;
     }
+  }
+
+  .skip-link {
+    position: absolute;
+    left: -9999em;
+  }
+
+  .skip-link:focus {
+    left: 0;
+    z-index: 1; /* or larger if necessary */
   }
 </style>


### PR DESCRIPTION
Update the default layout to have a link skipping past the header to the main content of the page. Followed the suggestions given here: https://webplatform.news/issues/2020-05-26. Addresses issue #122.