### PR TITLE
Add alt text to new icons

### DIFF
--- a/components/SiteHeaderNavBarSearchBar.vue
+++ b/components/SiteHeaderNavBarSearchBar.vue
@@ -2,7 +2,7 @@
   <div class="search-bar" :class="{ active: isActive }">
         <span class="input-wrapper">
             <span class="search-icon">
-                <img src="@/assets/icons/magnifying-glass.svg" :class="{ loading: isLoading }" />
+                <img src="@/assets/icons/magnifying-glass.svg" :class="{ loading: isLoading }" alt="Magnifying glass icon"/>
             </span>
             <input class="search-input"
                    type="text"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -37,23 +37,23 @@
       <h3>Follow Audioxide</h3>
       <ul class="social-icons">
         <li>
-          <span class="icon"><img src="@/assets/icons/envelope-closed.svg"/></span>
+          <span class="icon"><img src="@/assets/icons/envelope-closed.svg" alt="Envelope icon"/></span>
           <a class="label" :href="NEWSLETTER_URL">Newsletter</a>
         </li>
         <li>
-          <span class="icon"><img src="@/assets/icons/facebook.svg"/></span>
+          <span class="icon"><img src="@/assets/icons/facebook.svg" alt="Facebook logo"/></span>
           <a class="label" :href="FACEBOOK_URL" rel="me">Facebook</a>
         </li>
         <li>
-          <span class="icon"><img src="@/assets/icons/twitter.svg"/></span>
+          <span class="icon"><img src="@/assets/icons/twitter.svg" alt="Twitter logo"/></span>
           <a class="label" :href="TWITTER_URL" rel="me">Twitter</a>
         </li>
         <li>
-          <span class="icon"><img src="@/assets/icons/instagram.svg"/></span>
+          <span class="icon"><img src="@/assets/icons/instagram.svg" alt="Instagram logo"/></span>
           <a class="label" :href="INSTAGRAM_URL" rel="me">Insta</a>
         </li>
         <li>
-          <span class="icon"><img src="@/assets/icons/rss.svg"/></span>
+          <span class="icon"><img src="@/assets/icons/rss.svg" alt="RSS icon"/></span>
           <a class="label" :href="RSS_BASE">RSS</a>
         </li>
       </ul>

--- a/pages/random.vue
+++ b/pages/random.vue
@@ -1,6 +1,6 @@
 <template>
     <main>
-        <img src="@/assets/icons/brain.svg" class="random-icon"/>
+        <img src="@/assets/icons/brain.svg" class="random-icon" alt="Brain icon"/>
     </main>
 </template>
 

--- a/pages/reviews/_slug.vue
+++ b/pages/reviews/_slug.vue
@@ -41,7 +41,7 @@
                 <img class="review-sidebar__album-cover" :alt="coverAlt" :src="review.metadata.featuredimage['medium-square']" :style="sidebarStyles" width="600" height="600" />
                 <template v-if="review.metadata.artworkCredit">
                     <figcaption class="review-sidebar__artwork-info" v-if="showCredit">The album artwork of <span class="album">{{ review.metadata.album }}</span> by {{ review.metadata.artist }} {{ review.metadata.artworkCredit }} <template v-if="review.metadata.artworkCreditSource"><a :href="review.metadata.artworkCreditSource" class="review-sidebar_artwork-source-link" target="_blank" rel="noopener" aria-label="Source link">Source <img class="review-sidebar__artwork-info-external-link" src="@/assets/icons/external-link.svg" /></a></template></figcaption>
-                    <img class="review-sidebar__artwork-info-icon" @click="showCredit = !showCredit" src="@/assets/icons/information.svg" />
+                    <img class="review-sidebar__artwork-info-icon" @click="showCredit = !showCredit" src="@/assets/icons/information.svg" alt="Information icon"/>
                 </template>
             </figure>
             </div>


### PR DESCRIPTION
Forgot to do this while weaning the site off Font Awesome (https://github.com/audioxide/website/pull/161). This gives alt text to the new icons for the benefit of screen readers, etc.