### PR TITLE
Have Stats page fetch review data then pass it into child components

### DIFF
--- a/components/StatsOverview.vue
+++ b/components/StatsOverview.vue
@@ -7,15 +7,15 @@
     </p>
     <ul>
       <li id="review-count">
-        To date Audioxide has reviewed {{ this.reviewData.length }} albums
+        To date Audioxide has reviewed {{ reviewData.length }} albums
       </li>
       <li id="average-overall-score">
         The sitewide average score is
-        {{ calculateAverageScore(this.reviewData) }} out of 30
+        {{ calculateAverageScore(reviewData) }} out of 30
       </li>
       <li id="27-plus-club">
         The <a href="/tags/27-plus-club/">27+ Club</a> currently has
-        {{ count27PlusClubMembers(this.reviewData) }} members
+        {{ count27PlusClubMembers(reviewData) }} members
       </li>
     </ul>
     <p>More coming soon.</p>
@@ -29,13 +29,6 @@ export default Vue.extend({
   name: 'StatsOverview',
   props: ['reviewData'],
   methods: {
-    async fetchData() {
-      const response = await fetch(
-        'https://gist.githubusercontent.com/frederickobrien/6c2239358cfa04d6aaf5f2275a864e56/raw/81e4a925db42361eaf1be69d3a1adfc94795ecec/reviews-data.json'
-      )
-      const fetchedData = await response.json()
-      return (this.reviewData = fetchedData)
-    },
     calculateAverageScore(data) {
       let scores = 0
       for (let i = 0; i < data.length; i++) {
@@ -50,11 +43,6 @@ export default Vue.extend({
       }
       return plusClubMembers
     }
-  },
-  created() {
-    this.fetchData().then(() => {
-      console.log(this.reviewData.length)
-    })
   }
 })
 </script>
@@ -86,7 +74,7 @@ li:before {
 
 @media (min-width: 1281px) {
   .stats-overview-card {
-    width: 50%;
+    width: 67%;
   }
 }
 </style>

--- a/components/StatsOverview.vue
+++ b/components/StatsOverview.vue
@@ -7,14 +7,15 @@
     </p>
     <ul>
       <li id="review-count">
-        To date Audioxide has reviewed {{ reviewData.length }} albums.
+        To date Audioxide has reviewed {{ this.reviewData.length }} albums
       </li>
       <li id="average-overall-score">
-        The sitewide average score is {{ calculateAverageScore(reviewData) }}
+        The sitewide average score is
+        {{ calculateAverageScore(this.reviewData) }} out of 30
       </li>
       <li id="27-plus-club">
         The <a href="/tags/27-plus-club/">27+ Club</a> currently has
-        {{ count27PlusClubMembers(reviewData) }} members
+        {{ count27PlusClubMembers(this.reviewData) }} members
       </li>
     </ul>
     <p>More coming soon.</p>
@@ -32,8 +33,8 @@ export default Vue.extend({
       const response = await fetch(
         'https://gist.githubusercontent.com/frederickobrien/6c2239358cfa04d6aaf5f2275a864e56/raw/81e4a925db42361eaf1be69d3a1adfc94795ecec/reviews-data.json'
       )
-      const data = await response.json()
-      return (this.reviewData = data)
+      const fetchedData = await response.json()
+      return (this.reviewData = fetchedData)
     },
     calculateAverageScore(data) {
       let scores = 0

--- a/components/StatsOverview.vue
+++ b/components/StatsOverview.vue
@@ -1,79 +1,91 @@
 <template>
-    <div class="stats-overview-card">
-        <p>Everything below is generated using the <a href="https://api.audioxide.com/reviews.json">Audioxide API</a>. 
-        It's all the stuff you wanted to know, and a few things you didn't.
-        </p>
-        <ul>
-            <li id="review-count"></li>
-            <li id="average-overall-score"></li>
-            <li id="27-plus-club"></li>
-        </ul>
-        <p>More coming soon.</p>
-    </div>
+  <div class="stats-overview-card">
+    <p>
+      Everything below is generated using the
+      <a href="https://api.audioxide.com/reviews.json">Audioxide API</a>. It's
+      all the stuff you wanted to know, and a few things you didn't.
+    </p>
+    <ul>
+      <li id="review-count">
+        To date Audioxide has reviewed {{ reviewData.length }} albums.
+      </li>
+      <li id="average-overall-score">
+        The sitewide average score is {{ calculateAverageScore(reviewData) }}
+      </li>
+      <li id="27-plus-club">
+        The <a href="/tags/27-plus-club/">27+ Club</a> currently has
+        {{ count27PlusClubMembers(reviewData) }} members
+      </li>
+    </ul>
+    <p>More coming soon.</p>
+  </div>
 </template>
 
 <script>
-import Vue from 'vue';
+import Vue from 'vue'
 
 export default Vue.extend({
-    name: 'StatsOverview',
-    created() {
-        fetch("https://api.audioxide.com/reviews.json")
-            .then(response => response.json())
-            .then(data => {
-                const albumCount = data.length;
-                let scores = 0;
-                let plusClubMembers = 0;
-
-                for (let i = 0; i < albumCount; i++) {
-                    scores += data[i].metadata.totalscore.given;
-                    if (data[i].metadata.totalscore.given >= 27) plusClubMembers++
-                }
-                const siteWideAverageScore = scores / albumCount;
-
-                document.getElementById('review-count').innerHTML = `To date Audioxide has reviewed ${albumCount} albums.`;
-                document.getElementById('average-overall-score').innerText = `The sitewide average score is ${Math.round(siteWideAverageScore * 100) / 100} out of 30.`;
-                document.getElementById('27-plus-club').innerHTML = `
-                    The <a href="/tags/27-plus-club/">27+ Club</a> currently has ${plusClubMembers} members.
-                    `;
-
-            });
+  name: 'StatsOverview',
+  props: ['reviewData'],
+  methods: {
+    async fetchData() {
+      const response = await fetch(
+        'https://gist.githubusercontent.com/frederickobrien/6c2239358cfa04d6aaf5f2275a864e56/raw/81e4a925db42361eaf1be69d3a1adfc94795ecec/reviews-data.json'
+      )
+      const data = await response.json()
+      return (this.reviewData = data)
+    },
+    calculateAverageScore(data) {
+      let scores = 0
+      for (let i = 0; i < data.length; i++) {
+        scores += data[i].metadata.totalscore.given
+      }
+      return Math.round((scores / data.length) * 100) / 100
+    },
+    count27PlusClubMembers(data) {
+      let plusClubMembers = 0
+      for (let i = 0; i < data.length; i++) {
+        if (data[i].metadata.totalscore.given >= 27) plusClubMembers++
+      }
+      return plusClubMembers
     }
-});
-
+  },
+  created() {
+    this.fetchData().then(() => {
+      console.log(this.reviewData.length)
+    })
+  }
+})
 </script>
 
 <style lang="scss" scoped>
-
-@import "~assets/styles/variables";
+@import '~assets/styles/variables';
 
 .stats-overview-card {
-    @include site-content__body-text;
-    margin: auto;
-    width: 95%;
+  @include site-content__body-text;
+  margin: auto;
+  padding-top: 1em;
+  width: 90%;
+  font-family: 'Spectral';
 }
 
 .stats-overview-card p {
-    margin-bottom: 10px;
+  margin-bottom: 10px;
 }
 
 li {
-    list-style-type: disc;
-    list-style-position: inside;
-    padding-bottom: 0.5em;
+  list-style-type: disc;
+  list-style-position: inside;
+  padding-bottom: 0.5em;
 }
 
 li:before {
-    color: black;
+  color: black;
 }
 
 @media (min-width: 1281px) {
-  
   .stats-overview-card {
-      width: 50%;
+    width: 50%;
   }
-  
 }
-
 </style>
-

--- a/pages/stats.vue
+++ b/pages/stats.vue
@@ -1,37 +1,51 @@
 <template>
   <main>
     <h2>Stats</h2>
-    <stats-overview :reviewData="{ reviewData }" />
+    <stats-overview :reviewData="this.reviewData" />
   </main>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
 import StatsOverview from '@/components/StatsOverview.vue'
+import { metaTitle } from '~/assets/utilities'
+
+const apiLink = 'https://api.audioxide.com/reviews.json'
+const dummyApiLinkForLocalDevelopment =
+  'https://gist.githubusercontent.com/frederickobrien/6c2239358cfa04d6aaf5f2275a864e56/raw/81e4a925db42361eaf1be69d3a1adfc94795ecec/reviews-data.json'
 
 export default Vue.extend({
-  data: {
-    reviewData: {}
-  },
-  methods: {
-    async fetchData() {
-      const response = await fetch(
-        'https://gist.githubusercontent.com/frederickobrien/6c2239358cfa04d6aaf5f2275a864e56/raw/81e4a925db42361eaf1be69d3a1adfc94795ecec/reviews-data.json'
-      )
-      const fetchedData = await response.json()
-      return fetchedData
+  data() {
+    return {
+      reviewData: {}
     }
   },
   created() {
-    this.reviewData = this.fetchData()
-    console.log(this.reviewData)
+    const fetchData = async () => {
+      const rawFetchedData = await fetch(apiLink)
+      const formattedFetchedData = await rawFetchedData.json()
+      this.reviewData = formattedFetchedData
+      console.log(this.reviewData)
+    }
+
+    fetchData()
   },
-  components: { StatsOverview }
+  components: { StatsOverview },
+  head() {
+    return {
+      title: metaTitle('Stats')
+    }
+  }
 })
 </script>
 
 <style lang="scss" scoped>
 @import '~assets/styles/variables';
+
+main {
+  width: 90%;
+  margin: auto;
+}
 
 h2 {
   text-align: center;
@@ -39,7 +53,16 @@ h2 {
   font-family: $heading-fontstack;
   margin-top: 1em;
 }
-</style>
 
-function fetchData() { throw new Error('Function not implemented.') } function
-fetchData() { throw new Error('Function not implemented.') }
+@include medium {
+  main {
+    width: 75%;
+  }
+}
+
+@include large {
+  main {
+    width: 50%;
+  }
+}
+</style>

--- a/pages/stats.vue
+++ b/pages/stats.vue
@@ -10,10 +10,6 @@ import Vue from 'vue'
 import StatsOverview from '@/components/StatsOverview.vue'
 import { metaTitle } from '~/assets/utilities'
 
-const apiLink = 'https://api.audioxide.com/reviews.json'
-const dummyApiLinkForLocalDevelopment =
-  'https://gist.githubusercontent.com/frederickobrien/6c2239358cfa04d6aaf5f2275a864e56/raw/81e4a925db42361eaf1be69d3a1adfc94795ecec/reviews-data.json'
-
 export default Vue.extend({
   data() {
     return {
@@ -22,7 +18,9 @@ export default Vue.extend({
   },
   created() {
     const fetchData = async () => {
-      const rawFetchedData = await fetch(apiLink)
+      const rawFetchedData = await fetch(
+        'https://api.audioxide.com/reviews.json'
+      )
       const formattedFetchedData = await rawFetchedData.json()
       this.reviewData = formattedFetchedData
       console.log(this.reviewData)

--- a/pages/stats.vue
+++ b/pages/stats.vue
@@ -1,7 +1,7 @@
 <template>
   <main>
     <h2>Stats</h2>
-    <stats-overview :reviewData="{ data }" />
+    <stats-overview :reviewData="{ reviewData }" />
   </main>
 </template>
 
@@ -10,12 +10,21 @@ import Vue from 'vue'
 import StatsOverview from '@/components/StatsOverview.vue'
 
 export default Vue.extend({
-  data: function() {
-    return fetch(
-      'https://gist.githubusercontent.com/frederickobrien/6c2239358cfa04d6aaf5f2275a864e56/raw/81e4a925db42361eaf1be69d3a1adfc94795ecec/reviews-data.json'
-    )
-      .then((response) => response.json())
-      .then((data) => data)
+  data: {
+    reviewData: {}
+  },
+  methods: {
+    async fetchData() {
+      const response = await fetch(
+        'https://gist.githubusercontent.com/frederickobrien/6c2239358cfa04d6aaf5f2275a864e56/raw/81e4a925db42361eaf1be69d3a1adfc94795ecec/reviews-data.json'
+      )
+      const fetchedData = await response.json()
+      return fetchedData
+    }
+  },
+  created() {
+    this.reviewData = this.fetchData()
+    console.log(this.reviewData)
   },
   components: { StatsOverview }
 })

--- a/pages/stats.vue
+++ b/pages/stats.vue
@@ -1,28 +1,36 @@
 <template>
   <main>
     <h2>Stats</h2>
-    <stats-overview />
+    <stats-overview :reviewData="{ data }" />
   </main>
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import StatsOverview from '@/components/StatsOverview.vue';
+import Vue from 'vue'
+import StatsOverview from '@/components/StatsOverview.vue'
 
 export default Vue.extend({
+  data: function() {
+    return fetch(
+      'https://gist.githubusercontent.com/frederickobrien/6c2239358cfa04d6aaf5f2275a864e56/raw/81e4a925db42361eaf1be69d3a1adfc94795ecec/reviews-data.json'
+    )
+      .then((response) => response.json())
+      .then((data) => data)
+  },
   components: { StatsOverview }
 })
-
 </script>
 
 <style lang="scss" scoped>
-    @import "~assets/styles/variables";
+@import '~assets/styles/variables';
 
-    h2 {
-        text-align: center;
-        font-size: 2em;
-        font-family: $heading-fontstack;
-        padding: 30px;
-    }
-
+h2 {
+  text-align: center;
+  font-size: 3em;
+  font-family: $heading-fontstack;
+  margin-top: 1em;
+}
 </style>
+
+function fetchData() { throw new Error('Function not implemented.') } function
+fetchData() { throw new Error('Function not implemented.') }


### PR DESCRIPTION
The first iteration of the stats page - although good for getting us off the ground - was generated by manipulating the DOM. This will not stand. This PR rejigs the stats page to take advantage of [Vue reactivity](https://vuejs.org/v2/guide/reactivity.html). Now we fetch the data once on the stats page then pass the result into any components it contains. There are a couple of advantages to this.

1. We only fetch the data once
2. It ensures that all stats-related components are playing with the same data

No doubt much of how I have gone about this is horrendous, but it is better than it was before and will be better still in time. 

It also implements further styling to make the page consistent with others on the site.