### PR TITLE
Add review type counts to /stats page

### DIFF
--- a/components/StatsOverview.vue
+++ b/components/StatsOverview.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable prettier/prettier -->
 <template>
   <div class="stats-overview-card">
     <p>
@@ -36,45 +35,31 @@ export default Vue.extend({
   name: 'StatsOverview',
   props: ['reviewData'],
   methods: {
-    calculateAverageScore(data) {
+    calculateSummaryStats(data) {
       let scores = 0
-      for (let i = 0; i < data.length; i++) {
-        scores += data[i].metadata.totalscore.given
-      }
-      return Math.round((scores / data.length) * 100) / 100
-    },
-    count27PlusClubMembers(data) {
       let plusClubMembers = 0
-      for (let i = 0; i < data.length; i++) {
-        if (data[i].metadata.totalscore.given >= 27) plusClubMembers++
+      const reviewTypeCounts = {
+        newRelease: 0,
+        retrospective: 0,
+        gag: 0
       }
-      return plusClubMembers
-    },
-    getReviewTypeCounts(data) {
-      let newRelease = 0
-      let retrospective = 0
-      let gag = 0
       for (let i = 0; i < data.length; i++) {
-        if (data[i].metadata.reviewType === 'newRelease') newRelease++
-        else if (data[i].metadata.reviewType === 'retrospective')
-          retrospective++
-        else if (data[i].metadata.reviewType === 'gag') gag++
-        else console.log('Review type not recognised. Album is:' + data[i].metadata.title)
+        // Average score
+        scores += data[i].metadata.totalscore.given
+        // 27+ Club members
+        if (data[i].metadata.totalscore.given >= 27) plusClubMembers++
+        // Release type counts
+        if (data[i].metadata.reviewType === 'newRelease')
+          reviewTypeCounts.newRelease++
+        if (data[i].metadata.reviewType === 'retrospective')
+          reviewTypeCounts.retrospective++
+        if (data[i].metadata.reviewType === 'gag') reviewTypeCounts.gag++
       }
       return {
-        newRelease,
-        retrospective,
-        gag
+        averageScore: Math.round((scores / data.length) * 100) / 100,
+        plusClubMembers,
+        reviewTypeCounts
       }
-    },
-    calculateSummaryStats(data) {
-      const summaryStats = {
-        averageScore: this.calculateAverageScore(data),
-        plusClubMembers: this.count27PlusClubMembers(data),
-        reviewTypeCounts: this.getReviewTypeCounts(data)
-      }
-      console.log(summaryStats)
-      return summaryStats
     }
   }
 })

--- a/components/StatsOverview.vue
+++ b/components/StatsOverview.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable prettier/prettier -->
 <template>
   <div class="stats-overview-card">
     <p>
@@ -7,15 +8,21 @@
     </p>
     <ul>
       <li id="review-count">
-        To date Audioxide has reviewed {{ reviewData.length }} albums
+        To date Audioxide has reviewed {{ reviewData.length }} albums. Of these
+        {{ calculateSummaryStats(reviewData).reviewTypeCounts.newRelease }} were
+        new releases,
+        {{ calculateSummaryStats(reviewData).reviewTypeCounts.retrospective }}
+        were retrospectives, and
+        {{ calculateSummaryStats(reviewData).reviewTypeCounts.gag }} weren't
+        strictly serious.
       </li>
       <li id="average-overall-score">
         The sitewide average score is
-        {{ calculateAverageScore(reviewData) }} out of 30
+        {{ calculateSummaryStats(reviewData).averageScore }} out of 30
       </li>
       <li id="27-plus-club">
         The <a href="/tags/27-plus-club/">27+ Club</a> currently has
-        {{ count27PlusClubMembers(reviewData) }} members
+        {{ calculateSummaryStats(reviewData).plusClubMembers }} members
       </li>
     </ul>
     <p>More coming soon.</p>
@@ -42,6 +49,32 @@ export default Vue.extend({
         if (data[i].metadata.totalscore.given >= 27) plusClubMembers++
       }
       return plusClubMembers
+    },
+    getReviewTypeCounts(data) {
+      let newRelease = 0
+      let retrospective = 0
+      let gag = 0
+      for (let i = 0; i < data.length; i++) {
+        if (data[i].metadata.reviewType === 'newRelease') newRelease++
+        else if (data[i].metadata.reviewType === 'retrospective')
+          retrospective++
+        else if (data[i].metadata.reviewType === 'gag') gag++
+        else console.log('Review type not recognised. Album is:' + data[i].metadata.title)
+      }
+      return {
+        newRelease,
+        retrospective,
+        gag
+      }
+    },
+    calculateSummaryStats(data) {
+      const summaryStats = {
+        averageScore: this.calculateAverageScore(data),
+        plusClubMembers: this.count27PlusClubMembers(data),
+        reviewTypeCounts: this.getReviewTypeCounts(data)
+      }
+      console.log(summaryStats)
+      return summaryStats
     }
   }
 })

--- a/pages/stats.vue
+++ b/pages/stats.vue
@@ -10,6 +10,8 @@ import Vue from 'vue'
 import StatsOverview from '@/components/StatsOverview.vue'
 import { metaTitle } from '~/assets/utilities'
 
+const reviewDataLocation = 'https://api.audioxide.com/reviews.json'
+
 export default Vue.extend({
   data() {
     return {
@@ -18,9 +20,7 @@ export default Vue.extend({
   },
   created() {
     const fetchData = async () => {
-      const rawFetchedData = await fetch(
-        'https://api.audioxide.com/reviews.json'
-      )
+      const rawFetchedData = await fetch(reviewDataLocation)
       const formattedFetchedData = await rawFetchedData.json()
       this.reviewData = formattedFetchedData
       console.log(this.reviewData)

--- a/pages/stats.vue
+++ b/pages/stats.vue
@@ -1,7 +1,7 @@
 <template>
   <main>
     <h2>Stats</h2>
-    <stats-overview :reviewData="this.reviewData" />
+    <stats-overview :review-data="reviewData" />
   </main>
 </template>
 
@@ -13,9 +13,15 @@ import { metaTitle } from '~/assets/utilities'
 const reviewDataLocation = 'https://api.audioxide.com/reviews.json'
 
 export default Vue.extend({
+  components: { StatsOverview },
   data() {
     return {
       reviewData: {}
+    }
+  },
+  head() {
+    return {
+      title: metaTitle('Stats')
     }
   },
   created() {
@@ -23,16 +29,9 @@ export default Vue.extend({
       const rawFetchedData = await fetch(reviewDataLocation)
       const formattedFetchedData = await rawFetchedData.json()
       this.reviewData = formattedFetchedData
-      console.log(this.reviewData)
     }
 
     fetchData()
-  },
-  components: { StatsOverview },
-  head() {
-    return {
-      title: metaTitle('Stats')
-    }
   }
 })
 </script>


### PR DESCRIPTION
This PR updates the /stats page to include counts of our different review types, cycling through the reviews and tallying up the different `reviewType` values:

- New releases (`newRelease`)
- Retrospective (`retrospective`)
- Gag (`gag`)

The result looks like this:

![image](https://user-images.githubusercontent.com/11380557/221380563-717e2753-5560-4502-bea1-5f2a27779bb3.png)

This is in addition to the overall count. Plenty more that can be done with this page, but a nice little step to get back into the Audioxide dev groove.