### PR TITLE
Apply emergency API image workaround in a couple more places

### DIFF
--- a/src/lib/components/posts/Post.svelte
+++ b/src/lib/components/posts/Post.svelte
@@ -69,7 +69,7 @@
 	{#if metadata.type === 'listening-parties'}
 		<ListeningPartyChat html={content} />
 	{:else}
-		<ContentBlock html={imageUrlHack(content)} />
+		<ContentBlock html={content} />
 	{/if}
 	<div class="related">
 		<RelatedTags relatedTags={metadata.tags} />

--- a/src/lib/components/posts/Post.svelte
+++ b/src/lib/components/posts/Post.svelte
@@ -69,7 +69,7 @@
 	{#if metadata.type === 'listening-parties'}
 		<ListeningPartyChat html={content} />
 	{:else}
-		<ContentBlock html={content} />
+		<ContentBlock html={imageUrlHack(content)} />
 	{/if}
 	<div class="related">
 		<RelatedTags relatedTags={metadata.tags} />

--- a/src/lib/types/shared.ts
+++ b/src/lib/types/shared.ts
@@ -76,3 +76,12 @@ export interface ReviewSection {
 	};
 	tracks: string[];
 }
+
+export interface BannerAlbums {
+	image: string;
+	score: number;
+	artist: string;
+	album: string;
+	slug: string;
+}
+[];

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,8 +1,9 @@
 import { API_URL } from '$lib/constants';
+import type { BannerAlbums } from '$lib/types/shared.js';
 
 export const load = async ({ fetch }) => {
 	const response = await fetch(`${API_URL}/albumbanner.json`);
-	const bannerReviews = await response.json();
+	const bannerReviews: BannerAlbums = await response.json();
 	return {
 		bannerReviews
 	};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,7 +26,7 @@
 </script>
 
 <svelte:head>
-	{#if !dev && $navigating}
+	{#if !dev}
 		<script
 			data-n-head="ssr"
 			data-goatcounter="https://audioxide.goatcounter.com/count"

--- a/src/routes/articles/[slug]/+page.server.ts
+++ b/src/routes/articles/[slug]/+page.server.ts
@@ -1,7 +1,12 @@
 import { API_URL } from '$lib/constants';
+import type { GenericPost } from '$lib/types/shared.js';
+import { imageUrlHack } from '../../../utils/index.js';
 
 export async function load({ fetch, params }) {
 	const response = await fetch(`${API_URL}/posts/articles-${params.slug}.json`);
-	const article = await response.json();
-	return { article };
+	const article: GenericPost = await response.json();
+	return {
+		...article,
+		content: imageUrlHack(article.content)
+	};
 }

--- a/src/routes/articles/[slug]/+page.server.ts
+++ b/src/routes/articles/[slug]/+page.server.ts
@@ -1,12 +1,8 @@
 import { API_URL } from '$lib/constants';
 import type { GenericPost } from '$lib/types/shared.js';
-import { imageUrlHack } from '../../../utils/index.js';
 
 export async function load({ fetch, params }) {
 	const response = await fetch(`${API_URL}/posts/articles-${params.slug}.json`);
 	const article: GenericPost = await response.json();
-	return {
-		...article,
-		content: imageUrlHack(article.content)
-	};
+	return { article };
 }

--- a/src/routes/articles/[slug]/+page.svelte
+++ b/src/routes/articles/[slug]/+page.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import Post from '$lib/components/posts/Post.svelte';
-	import type { GenericPost } from '$lib/types/shared';
 
-	let { data }: { data: { article: GenericPost } } = $props();
+	let { data } = $props();
 </script>
 
 <Post post={data.article} />

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -11,6 +11,7 @@ import {
 } from '$lib/constants';
 import type { ReviewMetadata } from '$lib/types/reviews';
 import type { SharedPostMetadata } from '$lib/types/shared';
+import { imageUrlHack } from '.';
 
 export const audioxideStructuredData = () => ({
 	'@context': 'http://schema.org',
@@ -57,7 +58,7 @@ export const createReviewStructuredData = (metadata: ReviewMetadata) => {
 				'@type': 'MusicAlbum',
 				name: metadata.album,
 				'@id': `https://musicbrainz.org/release-group/${metadata.albumMBID}`,
-				image: (metadata.featuredimage || {})['medium-square'] || '',
+				image: imageUrlHack((metadata.featuredimage || {})['medium-square']) || '',
 				albumReleaseType: 'http://schema.org/AlbumRelease',
 				byArtist: {
 					'@type': 'MusicGroup',


### PR DESCRIPTION
This adds the API image replacement workaround to the schema plus a bit of extra typing. Just to steady the ship until the data side is sorted.

Tried applying it to article HTML as inline images are currently broken but that went south so rolled back a bit.