### PR TITLE
Roll back API image URL workaround/hack

### DIFF
--- a/src/lib/components/PostSummaryCard.svelte
+++ b/src/lib/components/PostSummaryCard.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { imageUrlHack } from '../../utils';
-
 	let {
 		image,
 		title,
@@ -27,7 +25,7 @@
 			? primaryColor
 			: '#f5f5f5'}; --aspect-ratio: {aspectRatio};"
 	>
-		<img loading="lazy" src={imageUrlHack(image)} alt={title} class:border={primaryColor} />
+		<img loading="lazy" src={image} alt={title} class:border={primaryColor} />
 		<div>
 			<h3>{title}</h3>
 			<div class="blurb">{blurb}</div>

--- a/src/lib/components/homepage/FeaturedPost.svelte
+++ b/src/lib/components/homepage/FeaturedPost.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import type { SharedPostMetadata } from '$lib/types/shared';
-	import { imageUrlHack } from '../../../utils';
 
 	let { post }: { post: SharedPostMetadata } = $props();
 
@@ -12,7 +11,7 @@
 	<div class="post-container">
 		<img
 			class="post-image"
-			src={imageUrlHack(post.featuredimage['medium-original'])}
+			src={post.featuredimage['medium-original']}
 			alt={post.featuredimageAlt}
 			style={`aspect-ratio: ${imageAspectRatio};`}
 		/>

--- a/src/lib/components/layout/HeaderAlbumBanner.svelte
+++ b/src/lib/components/layout/HeaderAlbumBanner.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import type { RecentReviewSummary } from '$lib/types/reviews';
-	import { imageUrlHack } from '../../../utils';
 
 	let {
 		recentReviews
@@ -22,7 +21,7 @@
 			<div class="square">
 				<img
 					class="album-artwork"
-					src={imageUrlHack(recentReview.image)}
+					src={recentReview.image}
 					alt={`Album artwork of '${recentReview.album}' by ${recentReview.artist}`}
 				/>
 				<div class="score-container">

--- a/src/lib/components/posts/Post.svelte
+++ b/src/lib/components/posts/Post.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { SITE_NAME, SITE_URL } from '$lib/constants';
 	import type { SharedPostMetadata } from '$lib/types/shared';
-	import { imageUrlHack } from '../../../utils';
 	import { createPostStructuredData } from '../../../utils/schema';
 	import ContentBlock from '../ContentBlock.svelte';
 	import OpenGraphMetaTags from '../layout/OpenGraphMetaTags.svelte';
@@ -56,7 +55,7 @@
 	<figure>
 		<img
 			loading="lazy"
-			src={imageUrlHack(metadata.featuredimage['medium-original'])}
+			src={metadata.featuredimage['medium-original']}
 			alt={metadata.featuredimageAlt}
 		/>
 		{#if metadata.featuredImageCaption}

--- a/src/lib/components/reviews/ReviewSummaryCardArtwork.svelte
+++ b/src/lib/components/reviews/ReviewSummaryCardArtwork.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { icons } from '$lib/styles/icons';
 	import type { ReviewMetadata } from '$lib/types/reviews';
-	import { imageUrlHack } from '../../../utils';
 	import Icon from '../Icon.svelte';
 	import InfoIcon from '../InfoIcon.svelte';
 
@@ -14,7 +13,7 @@
 	<figure>
 		<img
 			class="album-cover"
-			src={imageUrlHack(review.featuredimage['small-square'])}
+			src={review.featuredimage['small-square']}
 			alt={`Album artwork of '${review.album}' by ${review.artist}`}
 		/>
 		{#if review.artworkCredit}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,3 @@
-import { API_URL } from '$lib/constants';
 import type { AuthorLinks } from '$lib/types/shared';
 
 export const getAuthorLink = (authorLinks: AuthorLinks, authorSlug: string) => {
@@ -21,8 +20,4 @@ export const getAuthorLink = (authorLinks: AuthorLinks, authorSlug: string) => {
 		default:
 			return `/authors/${authorSlug}`;
 	}
-};
-
-export const imageUrlHack = (url: string) => {
-	return url.replace('https://audioxide.com/api', API_URL);
 };

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -11,7 +11,6 @@ import {
 } from '$lib/constants';
 import type { ReviewMetadata } from '$lib/types/reviews';
 import type { SharedPostMetadata } from '$lib/types/shared';
-import { imageUrlHack } from '.';
 
 export const audioxideStructuredData = () => ({
 	'@context': 'http://schema.org',
@@ -58,7 +57,7 @@ export const createReviewStructuredData = (metadata: ReviewMetadata) => {
 				'@type': 'MusicAlbum',
 				name: metadata.album,
 				'@id': `https://musicbrainz.org/release-group/${metadata.albumMBID}`,
-				image: imageUrlHack((metadata.featuredimage || {})['medium-square']) || '',
+				image: (metadata.featuredimage || {})['medium-square'] || '',
 				albumReleaseType: 'http://schema.org/AlbumRelease',
 				byArtist: {
 					'@type': 'MusicGroup',


### PR DESCRIPTION
This removes the `imageUrlHack()` function and all its uses (https://github.com/audioxide/website/pull/184, https://github.com/audioxide/website/pull/186) now that the underlying issue has been resolved (see https://github.com/audioxide/data/pull/109). All images are loading nicely again.

Lesson: be sure local environment variables match production ones!