### PR TITLE
Render extra/guest reviews

### DIFF
--- a/src/lib/components/reviews/ReviewSection.svelte
+++ b/src/lib/components/reviews/ReviewSection.svelte
@@ -16,18 +16,22 @@
 	<h3>{contentBlock.author.authors[0].forename}</h3>
 	<ContentBlock html={contentBlock.review} />
 	<div class="tracks-and-scores-container">
-		<div class="fav-tracks">
-			<h4>Favourite tracks //</h4>
-			<ol>
-				{#each contentBlock.tracks as track, i}
-					<li style="margin-left: {i}rem">{track}</li>
-				{/each}
-			</ol>
-		</div>
-		<div class="score">
-			<span class="score-given">{contentBlock.score.score}</span>
-			/{contentBlock.score.max}
-		</div>
+		{#if contentBlock.tracks}
+			<div class="fav-tracks">
+				<h4>Favourite tracks //</h4>
+				<ol>
+					{#each contentBlock.tracks as track, i}
+						<li style="margin-left: {i}rem">{track}</li>
+					{/each}
+				</ol>
+			</div>
+		{/if}
+		{#if contentBlock.score}
+			<div class="score">
+				<span class="score-given">{contentBlock.score.score}</span>
+				/{contentBlock.score.max}
+			</div>
+		{/if}
 	</div>
 </div>
 {#if !isLast}

--- a/src/lib/types/shared.ts
+++ b/src/lib/types/shared.ts
@@ -69,12 +69,12 @@ export interface ReviewSection {
 		authors: AuthorObject[];
 	};
 	review: string;
-	score: {
+	score?: {
 		score: number;
 		max: number;
 		fraction: number;
 	};
-	tracks: string[];
+	tracks?: string[];
 }
 
 export interface BannerAlbums {


### PR DESCRIPTION
Tweaks types and the `ReviewSection` component so that guest posts - i.e. posts without scores or favourite tracks - render instead of breaking the page. This is how it looks one such page:

![image](https://github.com/user-attachments/assets/f554a44b-bea9-42bf-a00f-7ff69c50b9b8)

We used to have bespoke styling for these extra summaries (dark background and light text if I remember right) but I quite like this clean approach so rolling with it for now.