### PR TITLE
Use fourth review colour where applicable

### DIFF
--- a/src/lib/components/reviews/ReviewSummaryCard.svelte
+++ b/src/lib/components/reviews/ReviewSummaryCard.svelte
@@ -15,7 +15,8 @@
 	class="summary-card"
 	style="--primary-color: {review.colours[0]}; 
 		   --secondary-color: {review.colours[1]}; 
-		   --tertiary-color: {review.colours[2]}"
+		   --tertiary-color: {review.colours[2]};
+		   --summary-text-color: {review.colours[3] ? review.colours[3] : review.colours[0]};"
 >
 	<ReviewSummaryCardArtwork {review} />
 	{#if review.totalscore.given >= 21}
@@ -61,7 +62,7 @@
 		position: relative;
 	}
 	.summary {
-		color: var(--primary-color);
+		color: var(--summary-text-color);
 		font-family: 'Spectral', serif;
 		padding: 1rem;
 		font-style: italic;


### PR DESCRIPTION
A step towards https://github.com/audioxide/data/issues/112, this tweaks CSS in the `ReviewSummaryCard` component to use a fourth colour for review summaries when they appear (added to a few reviews as a proof of concept on the data side here: https://github.com/audioxide/data/pull/111).

| Before    | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/11598cec-9834-4e46-8dc8-fc43fc778492)  | ![image](https://github.com/user-attachments/assets/4ec1fb31-9a48-4274-b34e-ff37f0bed63f)|

Beautiful and accessible is the goal and I think this approach gets us closer to that overlap. I want all reviews to at least pass WCAG AA standards by the end of this process.

Partly inspired by recent conversations with @anna-0.